### PR TITLE
Make storage backends pluggable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+ebin/riak_dt.app
 *.beam
 .eunit
 deps/*

--- a/rebar.config
+++ b/rebar.config
@@ -3,5 +3,6 @@
 {erl_opts, [debug_info, warnings_as_errors, {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {riak_kv, "1.2.*", {git, "git://github.com/basho/riak_kv", "master"}}
+        {riak_core, "1.2.*", {git, "git://github.com/basho/riak_core", "master"}},
+        {bitcask, "1.5.*", {git, "git://github.com/basho/bitcask", "master"}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,7 @@
 %% -*- erlang -*-
-{sub_dirs, ["rel"]}.
 {cover_enabled, true}.
 {erl_opts, [debug_info, warnings_as_errors, {parse_transform, lager_transform}]}.
-{edoc_opts, [{dir, "../../doc"}]}.
-{deps, [{riak_core, "1.2.*",
-         {git, "git://github.com/basho/riak_core", "master"}},
-        {bitcask, ".*", {git, "git://github.com/basho/bitcask", "master"}}
+{eunit_opts, [verbose]}.
+{deps, [
+        {riak_kv, "1.2.*", {git, "git://github.com/basho/riak_kv", "master"}}
        ]}.

--- a/src/riak_dt.app.src
+++ b/src/riak_dt.app.src
@@ -7,6 +7,8 @@
   {applications, [
                   kernel,
                   stdlib,
+                  lager,
+                  webmachine,
                   riak_core
                  ]},
   {mod, { riak_dt_app, []}},

--- a/src/riak_dt_app.erl
+++ b/src/riak_dt_app.erl
@@ -34,7 +34,6 @@
 start(_StartType, _StartArgs) ->
     case riak_dt_sup:start_link() of
         {ok, Pid} ->
-            ok = lager:start(),
             riak_core:register(riak_dt, [
                 {vnode_module, riak_dt_vnode}
             ]),

--- a/src/riak_dt_vnode.erl
+++ b/src/riak_dt_vnode.erl
@@ -227,6 +227,10 @@ do_merge({Mod, Key}, RemoteVal, StorageState) ->
     end.
 
 
+%% -------------------
+%% Storage engine
+%% -------------------
+
 %% @doc Initializes the internal storage engine where datatypes are
 %% persisted.
 -spec start_storage(Partition :: integer()) ->
@@ -239,7 +243,6 @@ start_storage(Partition) ->
         Cask ->
             {ok, Cask}
     end.
-
 
 %% @doc Stops the internal storage engine.
 -spec stop_storage(StorageState :: term()) ->
@@ -277,9 +280,9 @@ fold(Fun, Acc, StorageState) ->
 
 
 %% @doc Determines whether the persistent storage is empty.
--spec db_is_empty(StorageState :: term()) ->
-                      boolean().
+-spec db_is_empty(StorageState :: term()) -> boolean().
 db_is_empty(StorageState) ->
+
     %% Taken, verabtim, from riak_kv_bitcask_backend.erl
     %% Determining if a bitcask is empty requires us to find at least
     %% one value that is NOT a tombstone. Accomplish this by doing a fold_keys
@@ -314,7 +317,7 @@ make_mkey(ModKey) ->
 -spec get_data_dir(integer()) ->
                                 {ok, PartitionRoot :: string()}.
 get_data_dir(Partition) ->
-    DataRoot = app_helper:get_env(riak_dt, data_root, "data/crdt_bitcask"),
+    DataRoot = app_helper:get_env(riak_dt, data_root, "data/riak_dt_bitcask"),
     PartitionRoot = filename:join(DataRoot, integer_to_list(Partition)),
     ok = filelib:ensure_dir(PartitionRoot),
     {ok, PartitionRoot}.

--- a/src/riak_dt_vnode.erl
+++ b/src/riak_dt_vnode.erl
@@ -40,7 +40,7 @@
          handle_coverage/4,
          handle_exit/3]).
 
-%% CRDT API
+%% DT API
 -export([value/4,
          update/4,
          merge/5,
@@ -48,38 +48,59 @@
 
 -type key() :: {Mod :: atom(), Key :: term()}.
 
+-type command() :: {value, Mod::module(), Key::term(), ReqId::term()} |
+                   {update, Mod::module(), Key::term(), Args::list()} |
+                   {merge, Mod::module(), Key::term(), {Mod::module(), RemoteVal::term()}, ReqId::term()}.
+
 -record(state, {partition, node, storage_state, vnode_id}).
 
 -define(MASTER, riak_dt_vnode_master).
 -define(sync(PrefList, Command, Master),
         riak_core_vnode_master:sync_command(PrefList, Command, Master)).
 
-%% API
+%% @doc Starts or retrieves the pid of the riak_dt_vnode for the given
+%% partition index.
+-spec start_vnode(partition()) -> {ok, pid()}.
 start_vnode(I) ->
     riak_core_vnode_master:get_vnode_pid(I, ?MODULE).
 
+%% @doc Retrieves the opaque value of the given data type and key.
+%% Used inside request FSMs.
+-spec value(riak_core_apl:preflist2(), module(), term(), term()) -> ok.
 value(PrefList, Mod, Key, ReqId) ->
     riak_core_vnode_master:command(PrefList, {value, Mod, Key, ReqId}, {fsm, undefined, self()}, ?MASTER).
 
-%% Call sync, at source
+%% @doc Updates the value of the specified data type on this index.
+-spec update(partition(), module(), term(), term()) -> ok.
 update(IdxNode, Mod, Key, Args) ->
     ?sync(IdxNode, {update, Mod, Key, Args}, ?MASTER).
 
-%% Call async at replica
+%% @doc Sends a state to the indexes in the preflist to merge with
+%% their local states.
+-spec merge(riak_core_apl:preflist2(), module(), term(), term(), term()) -> ok.
 merge(PrefList, Mod, Key, CRDT, ReqId) ->
     riak_core_vnode_master:command(PrefList, {merge, Mod, Key, CRDT, ReqId}, {fsm, undefined, self()}, ?MASTER).
 
-%% Call aysnc at replica, just a merge with no reply
+%% @doc Sends a read-repair of a value, which amounts to a merge with
+%% no reply.
+-spec repair(riak_core_apl:preflist2(), module(), term(), term()) -> ok.
 repair(PrefList, Mod, Key, CRDT) ->
     riak_core_vnode_master:command(PrefList, {merge, Mod, Key, CRDT, ignore}, ignore, ?MASTER).
 
-%% Vnode API
+%% --------------------
+%% riak_core_vnode API
+%% --------------------
+
+%% @doc Initializes the riak_dt_vnode.
+-spec init([partition()]) -> {ok, #state{}}.
 init([Partition]) ->
     Node = node(),
     VnodeId = {node(), Partition, erlang:now()},
     {ok, StorageState} = start_storage(Partition),
     {ok, #state { partition=Partition, node=Node, storage_state=StorageState, vnode_id=VnodeId }}.
 
+%% @doc Handles incoming vnode commands.
+-spec handle_command(command(), sender(), #state{}) -> {noreply, #state{}} | {reply, term(), #state{}}.
 handle_command({value, Mod, Key, ReqId}, Sender, #state{partition=Idx, node=Node, storage_state=StorageState}=State) ->
     lager:debug("value ~p ~p~n", [Mod, Key]),
     Reply = lookup({Mod, Key}, StorageState),
@@ -113,46 +134,81 @@ handle_command(Message, _Sender, State) ->
     ?PRINT({unhandled_command, Message}),
     {noreply, State}.
 
+%% @doc Handles commands while in the handoff state.
+-spec handle_handoff_command(vnode_req(), sender(), #state{}) -> {reply, term(), #state{}}.
 handle_handoff_command(?FOLD_REQ{foldfun=Fun, acc0=Acc0}, _Sender, State=#state{storage_state=StorageState}) ->
     Acc = fold(Fun, Acc0, StorageState),
     {reply, Acc, State}.
 
+%% @doc Tells the vnode that handoff is starting.
+-spec handoff_starting({partition(), node()}, #state{}) -> {true, #state{}}.
 handoff_starting(_TargetNode, State) ->
     {true, State}.
 
+%% @doc Tells the vnode that handoff was cancelled.
+-spec handoff_cancelled(#state{}) -> {ok, #state{}}.
 handoff_cancelled(State) ->
     {ok, State}.
 
+%% @doc Tells the vnode that handoff finished.
+-spec handoff_finished({partition, node()}, #state{}) -> {ok, #state{}}.
 handoff_finished(_TargetNode, State) ->
     {ok, State}.
 
+%% @doc Decodes and receives a handoff value from the previous owner.
+%% For `riak_dt_vnode', the semantics of this is equivalent to a merge
+%% command.
+-spec handle_handoff_data(binary(), #state{}) -> {reply, ok, #state{}}.
 handle_handoff_data(Binary, #state{storage_state=StorageState}=State) ->
     {KB, VB} = binary_to_term(Binary),
     {{Mod, Key}, {Mod, HoffVal}} = {binary_to_term(KB), binary_to_term(VB)},
     ok = do_merge({Mod, Key}, HoffVal, StorageState),
     {reply, ok, State}.
 
+%% @doc Encodes a value to be sent over the wire in handoff.
+-spec encode_handoff_item(key(), term()) -> binary().
 encode_handoff_item(Name, Value) ->
     term_to_binary({Name, Value}).
 
+%% @doc Determines whether this vnode is empty, that is, has no data.
+-spec is_empty(#state{}) -> {true | false, #state{}}.
 is_empty(State) ->
     {db_is_empty(State#state.storage_state), State}.
 
+%% @doc Instructs the vnode to delete all its stored data.
+-spec delete(#state{}) -> {ok, #state{}}.
 delete(#state{storage_state=StorageState0, partition=Partition}=State) ->
     StorageState = drop_storage(StorageState0, Partition),
     {ok, State#state{storage_state=StorageState}}.
 
+%% @doc Handles coverage requests.
+-spec handle_coverage(vnode_req(), [{partition(), [partition()]}], sender(), #state{}) ->
+    {stop, not_implemented, #state{}}.
 handle_coverage(_Req, _KeySpaces, _Sender, State) ->
     {stop, not_implemented, State}.
 
+%% @doc Handles trapped exits from linked processes.
+-spec handle_exit(pid(), term(), #state{}) -> {noreply, #state{}}.
 handle_exit(_Pid, _Reason, State) ->
     {noreply, State}.
 
+%% @doc Terminates the vnode.
+-spec terminate(term(), #state{}) -> ok.
 terminate(_Reason, State) ->
     stop_storage(State#state.storage_state),
     ok.
 
-%% priv
+
+%% -------------------
+%% Internal functions
+%% -------------------
+
+%% @doc Performs a merge of a remote datatype into the local storage.
+%% The semantics of this are that if the key does not exist, the
+%% remote value will be accepted for the local state. If the key
+%% exists, the datatype-specific merge function will be called with
+%% the local and remote values and the merged value stored locally.
+-spec do_merge(key(), term(), term()) -> ok | {error, term()}.
 do_merge({Mod, Key}, RemoteVal, StorageState) ->
     Merged = case lookup({Mod, Key}, StorageState) of
                  notfound ->
@@ -170,7 +226,9 @@ do_merge({Mod, Key}, RemoteVal, StorageState) ->
             store({{Mod, Key}, {Mod, Merged}}, StorageState)
     end.
 
-%% Priv, storage stuff
+
+%% @doc Initializes the internal storage engine where datatypes are
+%% persisted.
 -spec start_storage(Partition :: integer()) ->
                            StorageState :: term().
 start_storage(Partition) ->
@@ -182,11 +240,15 @@ start_storage(Partition) ->
             {ok, Cask}
     end.
 
+
+%% @doc Stops the internal storage engine.
 -spec stop_storage(StorageState :: term()) ->
                            ok.
 stop_storage(StorageState) ->
     bitcask:close(StorageState).
 
+
+%% @doc Looks up a key in the persistent storage.
 -spec lookup(K :: key(), StorageState :: term()) ->
                     {ok, {atom(), term()}} | notfound | {error, Reason :: term()}.
 lookup(ModKey, StorageState) ->
@@ -200,17 +262,21 @@ lookup(ModKey, StorageState) ->
             {error, Reason}
     end.
 
+%% @doc Persists a datatype under the given key.
 -spec store({K :: key(), {atom(), term()}}, StorageState :: term()) ->
                    ok.
 store({Key, Value}, StorageState) ->
     MKey = make_mkey(Key),
     bitcask:put(StorageState, MKey, term_to_binary(Value)).
 
+%% @doc Folds over the persistent storage.
 -spec fold(function(), list(), StorageState :: term()) ->
                   list().
 fold(Fun, Acc, StorageState) ->
     bitcask:fold(StorageState, Fun, Acc).
 
+
+%% @doc Determines whether the persistent storage is empty.
 -spec db_is_empty(StorageState :: term()) ->
                       boolean().
 db_is_empty(StorageState) ->
@@ -223,6 +289,8 @@ db_is_empty(StorageState) ->
         end,
     (catch bitcask:fold_keys(StorageState, F, undefined)) /= found_one_value.
 
+
+%% @doc Drops the persistent storage, leaving no trace.
 -spec drop_storage(StorageState :: term(), Partition :: integer()) ->
                                                              reference().
 drop_storage(StorageState, Partition) ->
@@ -235,11 +303,14 @@ drop_storage(StorageState, Partition) ->
     {ok, Ref} = start_storage(Partition),
     Ref.
 
--spec make_mkey(key()) ->
-                       binary().
+
+%% @doc Creates a key appropriate for use in the persistent storage engine.
+-spec make_mkey(key()) -> binary().
 make_mkey(ModKey) ->
     term_to_binary(ModKey).
 
+%% @doc Determines the root of the persistent storage engine for the
+%% given partition.
 -spec get_data_dir(integer()) ->
                                 {ok, PartitionRoot :: string()}.
 get_data_dir(Partition) ->


### PR DESCRIPTION
We should be able to reuse Riak KV storage backends or make them otherwise pluggable.
