### PR TITLE
Seed random for uuid generation

### DIFF
--- a/src/riak_dt_vnode.erl
+++ b/src/riak_dt_vnode.erl
@@ -95,6 +95,7 @@ repair(PrefList, Mod, Key, CRDT) ->
 -spec init([partition()]) -> {ok, #state{}}.
 init([Partition]) ->
     Node = node(),
+    random:seed(erlang:now()), %% In this case we _DO_ want monotonicity
     VnodeId = uuid:v4(),
     StorageOptions = application:get_all_env(bitcask),
     {ok, DataDir, StorageState} = start_storage(Partition, StorageOptions),


### PR DESCRIPTION
If 'random' isn't seeded then duplicate vnodeids happen, and that's bad, since actors update each others entry in the counter.
