### PR TITLE
Ignore unsupported coverage requests

### DIFF
--- a/src/riak_dt_vnode.erl
+++ b/src/riak_dt_vnode.erl
@@ -195,9 +195,9 @@ delete(#state{storage_state=StorageState0, partition=Partition, storage_opts=Opt
 
 %% @doc Handles coverage requests.
 -spec handle_coverage(vnode_req(), [{partition(), [partition()]}], sender(), #state{}) ->
-    {stop, not_implemented, #state{}}.
+    {reply, not_implemented, #state{}}.
 handle_coverage(_Req, _KeySpaces, _Sender, State) ->
-    {stop, not_implemented, State}.
+    {reply, not_implemented, State}.
 
 %% @doc Handles trapped exits from linked processes.
 -spec handle_exit(pid(), term(), #state{}) -> {noreply, #state{}}.


### PR DESCRIPTION
Currently a coverage request will cause the vnode to stop/exit. Some coverage requests might need implementing (list-keys?) but others should just be ignored rather than killing the vnode.
