### PR TITLE
Fix semantics of counters resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ that doesn't exist it will be created for you.
 
 Create / increment a counter named `a`:
 
-    curl -X POST localhost:8091/counters/a/increment
+    curl -X POST localhost:8091/counters/a -d'1'
 
 Read it from any and all nodes:
 
@@ -75,20 +75,20 @@ Read it from any and all nodes:
 
 Increment by a specific amount:
 
-    curl -X POST localhost:8094/counters/a/increment -d"10"
+    curl -X POST localhost:8094/counters/a -d'10'
     curl localhost:809[1-4]/counters/a
 
 You can decrement a counter, too:
 
-    curl -X POST localhost:8092/counters/a/decrement
+    curl -X POST localhost:8092/counters/a -d'-1'
     curl localhost:809[1-4]/counters/a
-    curl -X POST localhost:8092/counters/a/decrement -d"8"
+    curl -X POST localhost:8092/counters/a -d'-8'
     curl localhost:809[1-4]/counters/a
 
 So, `counters` is the resource prefix for all counters, and the next
-part in the path is the key for your counter (in this case
-`a`). Finally there is the action, with optional payload. `POST` to
-update, `GET` to read.
+part in the path is the key for your counter (in this case `a`).
+Finally there is the action, with payload. `POST` to update, `GET` to
+read.
 
 ## CAVEATS
 

--- a/test/riak_dt_vnode_test.erl
+++ b/test/riak_dt_vnode_test.erl
@@ -109,4 +109,5 @@ verify_handoff_value_local(State) ->
     ?assertMatch({reply, {0, {{42, _Node}, notfound}}, _}, Result),
     {reply, _, NS} = Result,
     ?assert(true), 
+    meck:unload(),
     NS.

--- a/test/riak_dt_wm_test.erl
+++ b/test/riak_dt_wm_test.erl
@@ -3,7 +3,7 @@
 -compile([export_all]).
 
 -define(HTTP_PORT, 32767).
--define(URL, "http://localhost:32767").
+-define(URL, "http://127.0.0.1:32767").
 
 setup(load) ->
     application:set_env(riak_core, http, [{"127.0.0.1", ?HTTP_PORT}]),

--- a/test/riak_dt_wm_test.erl
+++ b/test/riak_dt_wm_test.erl
@@ -1,0 +1,52 @@
+-module(riak_dt_wm_test).
+-include_lib("eunit/include/eunit.hrl").
+-compile([export_all]).
+
+-define(HTTP_PORT, 32767).
+-define(URL, "http://localhost:32767").
+
+setup(load) ->
+    application:set_env(riak_core, http, [{"127.0.0.1", ?HTTP_PORT}]),
+    {ok, Dir} = application:get_env(riak_dt, data_root),
+    os:cmd("rm -rf " ++ Dir);
+setup(_) ->
+    ok.
+
+pncounter_update_test_() ->
+    {setup,
+     fun() ->
+             riak_dt_test_util:setup("pncounter_update_test", fun setup/1)
+     end,
+     fun riak_dt_test_util:cleanup/1,
+     [
+      fun pncounter_increment/0,
+      fun pncounter_decrement/0,
+      fun pncounter_update_errors/0
+     ]}.
+
+
+pncounter_increment() ->
+    ?assertMatch({ok, {{_, 204, _}, _, _}},
+                 httpc:request(post, {?URL ++ "/counters/pnincr", [], "text/plain", "1"}, [], [])),
+    ?assertMatch({ok, {{_, 200, _}, _, "1"}},
+                 httpc:request(?URL ++ "/counters/pnincr")),
+    ?assertMatch({ok, {{_, 204, _}, _, _}},
+                 httpc:request(post, {?URL ++ "/counters/pnincr", [], "text/plain", "5"}, [], [])),
+    ?assertMatch({ok, {{_, 200, _}, _, "6"}},
+                 httpc:request(?URL ++ "/counters/pnincr")).
+
+pncounter_decrement() ->
+    ?assertMatch({ok, {{_, 204, _}, _, _}},
+                 httpc:request(post, {?URL ++ "/counters/pndecr", [], "text/plain", "-1"}, [], [])),
+    ?assertMatch({ok, {{_, 200, _}, _, "-1"}},
+                 httpc:request(?URL ++ "/counters/pndecr")),
+    ?assertMatch({ok, {{_, 204, _}, _, _}},
+                 httpc:request(post, {?URL ++ "/counters/pndecr", [], "text/plain", "-5"}, [], [])),
+    ?assertMatch({ok, {{_, 200, _}, _, "-6"}},
+                 httpc:request(?URL ++ "/counters/pndecr")).
+
+pncounter_update_errors() ->
+    ?assertMatch({ok, {{_, 400, _}, _, _}},
+                 httpc:request(post, {?URL ++ "/counters/pnup", [], "text/plain", "-abc"}, [], [])),
+    ?assertMatch({ok, {{_, 400, _}, _, _}},
+                 httpc:request(post, {?URL ++ "/counters/pnup", [], "text/plain", ""}, [], [])).

--- a/test/riak_dt_wm_test.erl
+++ b/test/riak_dt_wm_test.erl
@@ -13,40 +13,45 @@ setup(_) ->
     ok.
 
 pncounter_update_test_() ->
-    {setup,
-     fun() ->
-             riak_dt_test_util:setup("pncounter_update_test", fun setup/1)
-     end,
-     fun riak_dt_test_util:cleanup/1,
-     [
-      fun pncounter_increment/0,
-      fun pncounter_decrement/0,
-      fun pncounter_update_errors/0
-     ]}.
-
+     {setup,
+      fun() ->
+              Result = riak_dt_test_util:setup("pncounter_update_test", fun setup/1),
+              ok = riak_dt_test_util:wait_for_port(?HTTP_PORT, 5000),
+              Result
+      end,
+      fun riak_dt_test_util:cleanup/1,
+      {inparallel,
+       [
+             fun pncounter_increment/0,
+             fun pncounter_decrement/0,
+             fun pncounter_update_errors/0
+       ]}
+     }.
 
 pncounter_increment() ->
-    ?assertMatch({ok, {{_, 204, _}, _, _}},
-                 httpc:request(post, {?URL ++ "/counters/pnincr", [], "text/plain", "1"}, [], [])),
-    ?assertMatch({ok, {{_, 200, _}, _, "1"}},
-                 httpc:request(?URL ++ "/counters/pnincr")),
-    ?assertMatch({ok, {{_, 204, _}, _, _}},
-                 httpc:request(post, {?URL ++ "/counters/pnincr", [], "text/plain", "5"}, [], [])),
-    ?assertMatch({ok, {{_, 200, _}, _, "6"}},
-                 httpc:request(?URL ++ "/counters/pnincr")).
+    ?assertMatch({ok, {{_, 204, _}, _, _}}, request_counter("pnincr", "1")),
+    ?assertMatch({ok, {{_, 200, _}, _, "1"}}, request_counter("pnincr")),
+    ?assertMatch({ok, {{_, 204, _}, _, _}},  request_counter("pnincr", "5")),
+    ?assertMatch({ok, {{_, 200, _}, _, "6"}}, request_counter("pnincr")).
 
 pncounter_decrement() ->
-    ?assertMatch({ok, {{_, 204, _}, _, _}},
-                 httpc:request(post, {?URL ++ "/counters/pndecr", [], "text/plain", "-1"}, [], [])),
-    ?assertMatch({ok, {{_, 200, _}, _, "-1"}},
-                 httpc:request(?URL ++ "/counters/pndecr")),
-    ?assertMatch({ok, {{_, 204, _}, _, _}},
-                 httpc:request(post, {?URL ++ "/counters/pndecr", [], "text/plain", "-5"}, [], [])),
-    ?assertMatch({ok, {{_, 200, _}, _, "-6"}},
-                 httpc:request(?URL ++ "/counters/pndecr")).
+    ?assertMatch({ok, {{_, 204, _}, _, _}}, request_counter("pndecr", "-1")),
+    ?assertMatch({ok, {{_, 200, _}, _, "-1"}}, request_counter("pndecr")),
+    ?assertMatch({ok, {{_, 204, _}, _, _}}, request_counter("pndecr", "-5")),
+    ?assertMatch({ok, {{_, 200, _}, _, "-6"}}, request_counter("pndecr")).
 
 pncounter_update_errors() ->
-    ?assertMatch({ok, {{_, 400, _}, _, _}},
-                 httpc:request(post, {?URL ++ "/counters/pnup", [], "text/plain", "-abc"}, [], [])),
-    ?assertMatch({ok, {{_, 400, _}, _, _}},
-                 httpc:request(post, {?URL ++ "/counters/pnup", [], "text/plain", ""}, [], [])).
+    ?assertMatch({ok, {{_, 400, _}, _, _}}, request_counter("pnup", "-abc")),
+    ?assertMatch({ok, {{_, 400, _}, _, _}}, request_counter("pnup", "")).
+
+request_counter(Key) ->
+    lager:debug("Fetching value of counter ~s~n", [Key]),
+    Result = httpc:request(?URL ++ "/counters/" ++ Key),
+    lager:debug("GET ~s returned ~p~n", [Key, Result]),
+    Result.
+
+request_counter(Key, Body) ->
+    lager:debug("Updating counter ~s with '~s'~n", [Key, Body]),
+    Result = httpc:request(post, {?URL ++ "/counters/" ++ Key , [], "text/plain", Body}, [], []),
+    lager:debug("POST ~s returned ~p~n", [Key, Result]),
+    Result.


### PR DESCRIPTION
The current counters increment and decrement like so:

```
POST /counters/a/increment
POST /counters/a/decrement
```

This is a bad practice as it puts the verb in the URL. It would be better to use form parameters or JSON to submit the "change". curl examples:

``` bash
curl http://riakhost:8098/counters/a -F increment=5
curl http://riakhost:8098/counters/a -F decrement=2
curl http://riakhost:8098/counters/a -d '{"increment":5}' -H "Content-Type: application/json"
```
