### PR TITLE
Garbage Compaction Ideas - Do Not Merge

### DIFF
--- a/include/riak_dt_gc.hrl
+++ b/include/riak_dt_gc.hrl
@@ -6,6 +6,7 @@
 -define(GC_META_ACTOR(GM), GM#riak_dt_gc_meta.actor).
 -record(riak_dt_gc_meta,
         {
+          epoch :: epoch(),             % Epoch of GC
           actor :: actor(),             % Actor performing the GC
           primary_actors :: [actor()],  % Actors most likely to be involved in operations
           readonly_actors :: [actor()], % Actors that can't be GCd (ie cluster remotes)

--- a/include/riak_dt_gc.hrl
+++ b/include/riak_dt_gc.hrl
@@ -1,9 +1,12 @@
 
 -type actor() :: term().
 
--define(GC_THRESHOLD, #riak_dt_gc_threshold).
--record(riak_dt_gc_threshold,
+-define(GC_META, #riak_dt_gc_meta).
+-define(GC_META_ACTOR(GM), GM#riak_dt_gc_meta.actor).
+-record(riak_dt_gc_meta,
         {
-          primary_actors :: [actor()], % Actors usually involved in 
-          max_unneeded :: float()      % Max Proportion of non-primary actors or tombstones
+          actor :: actor(),             % Actor performing the GC
+          primary_actors :: [actor()],  % Actors most likely to be involved in operations
+          readonly_actors :: [actor()], % Actors that can't be GCd (ie cluster remotes)
+          compact_proportion :: float()  % Max Proportion of non-primary actors or tombstones
         }).

--- a/include/riak_dt_gc.hrl
+++ b/include/riak_dt_gc.hrl
@@ -1,0 +1,9 @@
+
+-type actor() :: term().
+
+-define(GC_THRESHOLD, #riak_dt_gc_threshold).
+-record(riak_dt_gc_threshold,
+        {
+          primary_actors :: [actor()], % Actors usually involved in 
+          max_unneeded :: float()      % Max Proportion of non-primary actors or tombstones
+        }).

--- a/include/riak_dt_gc.hrl
+++ b/include/riak_dt_gc.hrl
@@ -1,5 +1,6 @@
 
 -type actor() :: term().
+-type epoch() :: {actor(), erlang:timestamp()}.
 
 -define(GC_META, #riak_dt_gc_meta).
 -define(GC_META_ACTOR(GM), GM#riak_dt_gc_meta.actor).
@@ -10,3 +11,4 @@
           readonly_actors :: [actor()], % Actors that can't be GCd (ie cluster remotes)
           compact_proportion :: float()  % Max Proportion of non-primary actors or tombstones
         }).
+-opaque gc_meta() :: #riak_dt_gc_meta{}.

--- a/src/riak_dt_disable_flag.erl
+++ b/src/riak_dt_disable_flag.erl
@@ -30,6 +30,9 @@
 -behaviour(riak_dt).
 
 -export([new/0, value/1, update/3, merge/2, equal/2]).
+-export([gc_ready/2, gc_propose/2, gc_execute/2]).
+
+-include("riak_dt_gc.hrl").
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -39,6 +42,8 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
+
+-opaque flag() :: on | off.
 
 %% EQC generator
 -ifdef(EQC).
@@ -68,6 +73,22 @@ merge(FA, FB) ->
 
 equal(FA,FB) ->
     FA =:= FB.
+
+%%% GC
+
+-type gc_op() :: {}.    
+
+-spec gc_ready(gc_meta(), flag()) -> boolean().
+gc_ready(_Meta, _Flag) ->
+    false.
+
+-spec gc_propose(gc_meta(), flag()) -> gc_op().
+gc_propose(_Meta, _Flag) ->
+    {}.
+
+-spec gc_execute(gc_op(), flag()) -> flag().
+gc_execute({}, Flag) ->
+    Flag.
 
 %% priv
 flag_and(on, on) ->

--- a/src/riak_dt_enable_flag.erl
+++ b/src/riak_dt_enable_flag.erl
@@ -30,6 +30,10 @@
 -behaviour(riak_dt).
 
 -export([new/0, value/1, update/3, merge/2, equal/2]).
+-export([gc_ready/2, gc_propose/2, gc_execute/2]).
+
+-include("riak_dt_gc.hrl").
+
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -39,6 +43,8 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
+
+-opaque flag() :: on | off.
 
 %% EQC generator
 -ifdef(EQC).
@@ -68,6 +74,21 @@ merge(FA, FB) ->
 
 equal(FA,FB) ->
     FA =:= FB.
+    
+    
+-type gc_op() :: {}.    
+
+-spec gc_ready(gc_meta(), flag()) -> boolean().
+gc_ready(_Meta, _Flag) ->
+    false.
+
+-spec gc_propose(gc_meta(), flag()) -> gc_op().
+gc_propose(_Meta, _Flag) ->
+    {}.
+
+-spec gc_execute(gc_op(), flag()) -> flag().
+gc_execute({}, Flag) ->
+    Flag.
 
 %% priv
 flag_or(on, _) ->

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -43,6 +43,7 @@
 -endif.
 
 -type gcounter() :: [{actor(), pos_integer()}].
+-export_type([gcounter/0]).
 
 %% EQC generator
 -ifdef(EQC).

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -43,7 +43,9 @@
 -export([gen_op/0, update_expected/3, eqc_state_value/1]).
 -endif.
 
+-define(GC_TAG, pncounter_gc_proposal).
 -type pncounter() :: {riak_dt_gcounter:gcounter(),riak_dt_gcounter:gcounter()}.
+-opaque gc_op() :: {?GC_TAG, riak_dt_gcounter:gc_op(), riak_dt_gcounter:gc_op()}.
 -export_type([pncounter/0]).
 
 %% EQC generator
@@ -94,7 +96,6 @@ equal({Incr1, Decr1}, {Incr2, Decr2}) ->
 
 %%% GC    
 
--type gc_op() :: term().
 
 % We're ready to GC if the actors we can't compact make up more than `compact_proportion` of
 % the actors in this GCounter.
@@ -107,10 +108,10 @@ gc_ready(Meta, {Incr,Decr}=_PNCnt) ->
 gc_propose(Meta, {Incr,Decr}=_PNCnt) ->
     IncrOp = riak_dt_gcounter:gc_propose(Meta, Incr),
     DecrOp = riak_dt_gcounter:gc_propose(Meta, Decr),
-    {?MODULE, IncrOp, DecrOp}.
+    {?GC_TAG, IncrOp, DecrOp}.
 
 -spec gc_execute(gc_op(), pncounter()) -> pncounter().
-gc_execute({?MODULE, IncrOp, DecrOp}, {Incr0,Decr0}=_PNCnt) ->
+gc_execute({?GC_TAG, IncrOp, DecrOp}, {Incr0,Decr0}=_PNCnt) ->
     Incr1 = riak_dt_gcounter:gc_execute(IncrOp, Incr0),
     Decr1 = riak_dt_gcounter:gc_execute(DecrOp, Decr0),
     {Incr1, Decr1}.

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -100,7 +100,8 @@ equal({Incr1, Decr1}, {Incr2, Decr2}) ->
 % the actors in this GCounter.
 -spec gc_ready(gc_meta(), pncounter()) -> boolean().
 gc_ready(Meta, {Incr,Decr}=_PNCnt) ->
-    riak_dt_gcounter:gc_ready(Meta, Incr) or riak_dt_pncounter:gc_ready(Meta, Decr).
+    riak_dt_gcounter:gc_ready(Meta, Incr) 
+    orelse riak_dt_gcounter:gc_ready(Meta, Decr).
 
 -spec gc_propose(gc_meta(), pncounter()) -> gc_op().
 gc_propose(Meta, {Incr,Decr}=_PNCnt) ->

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -34,11 +34,17 @@
 
 %% API
 -export([new/0, value/1, update/3, merge/2, equal/2]).
+-export([gc_ready/2, gc_propose/2, gc_execute/2]).
+
+-include("riak_dt_gc.hrl").
 
 %% EQC API
 -ifdef(EQC).
 -export([gen_op/0, update_expected/3, eqc_state_value/1]).
 -endif.
+
+-type pncounter() :: {riak_dt_gcounter:gcounter(),riak_dt_gcounter:gcounter()}.
+-export_type([pncounter/0]).
 
 %% EQC generator
 -ifdef(EQC).
@@ -85,6 +91,28 @@ merge({Incr1, Decr1}, {Incr2, Decr2}) ->
 
 equal({Incr1, Decr1}, {Incr2, Decr2}) ->
     riak_dt_gcounter:equal(Incr1, Incr2) andalso riak_dt_gcounter:equal(Decr1, Decr2).
+
+%%% GC    
+
+-type gc_op() :: term().
+
+% We're ready to GC if the actors we can't compact make up more than `compact_proportion` of
+% the actors in this GCounter.
+-spec gc_ready(gc_meta(), pncounter()) -> boolean().
+gc_ready(Meta, {Incr,Decr}=_PNCnt) ->
+    riak_dt_gcounter:gc_ready(Meta, Incr) or riak_dt_pncounter:gc_ready(Meta, Decr).
+
+-spec gc_propose(gc_meta(), pncounter()) -> gc_op().
+gc_propose(Meta, {Incr,Decr}=_PNCnt) ->
+    IncrOp = riak_dt_gcounter:gc_propose(Meta, Incr),
+    DecrOp = riak_dt_gcounter:gc_propose(Meta, Decr),
+    {?MODULE, IncrOp, DecrOp}.
+
+-spec gc_execute(gc_op(), pncounter()) -> pncounter().
+gc_execute({?MODULE, IncrOp, DecrOp}, {Incr0,Decr0}=_PNCnt) ->
+    Incr1 = riak_dt_gcounter:gc_execute(IncrOp, Incr0),
+    Decr1 = riak_dt_gcounter:gc_execute(DecrOp, Decr0),
+    {Incr1, Decr1}.
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_withgc.erl
+++ b/src/riak_dt_withgc.erl
@@ -84,9 +84,10 @@ equal(#dt_withgc{mod=Mod, dt=Inner1, epoch=Ep1},
 
 % construct a metadata object for all the info needed to do a GC
 -spec gc_meta(actor(), [actor()], [actor()], float()) -> gc_meta().
-gc_meta(Actor, PActors, ROActors, CompactProportion) ->
-    ?GC_META{actor=Actor,
-             primary_actors=ordsets:add_element(Actor, ordsets:from_list(PActors)), 
+gc_meta(Epoch, PActors, ROActors, CompactProportion) ->
+    ?GC_META{epoch=Epoch),
+             actor=epoch_actor(Epoch),
+             primary_actors=ordsets:from_list(PActors), 
              readonly_actors=ordsets:from_list(ROActors),
              compact_proportion=CompactProportion}.
 
@@ -99,8 +100,7 @@ gc_ready(Meta, #dt_withgc{mod=Mod, dt=Inner}) ->
 -spec gc_propose(gc_meta(), dt_withgc()) -> gc_op().
 gc_propose(Meta, #dt_withgc{mod=Mod, dt=Inner}) ->
     GCOperation = Mod:gc_propose(Meta, Inner),
-    Actor = ?GC_META_ACTOR(Meta),
-    {?MODULE, new_epoch(Actor), GCOperation}.
+    {?MODULE, Meta?GC_META.epoch, GCOperation}.
 
 -spec gc_execute(gc_op(), dt_withgc()) -> dt_withgc().
 gc_execute({?MODULE, Epoch, Op}=GcOp,

--- a/src/riak_dt_withgc.erl
+++ b/src/riak_dt_withgc.erl
@@ -86,8 +86,8 @@ equal(#dt_withgc{mod=Mod, dt=Inner1, epoch=Ep1},
 -spec gc_meta(actor(), [actor()], [actor()], float()) -> gc_meta().
 gc_meta(Actor, PActors, ROActors, CompactProportion) ->
     ?GC_META{actor=Actor,
-             primary_actors=PActors, 
-             readonly_actors=ROActors,
+             primary_actors=ordsets:add_element(Actor, ordsets:from_list(PActors)), 
+             readonly_actors=ordsets:from_list(ROActors),
              compact_proportion=CompactProportion}.
 
 % Check if the GC should be performed, using the provided metadata + threshold

--- a/src/riak_dt_withgc.erl
+++ b/src/riak_dt_withgc.erl
@@ -85,7 +85,7 @@ equal(#dt_withgc{mod=Mod, dt=Inner1, epoch=Ep1},
 % construct a metadata object for all the info needed to do a GC
 -spec gc_meta(actor(), [actor()], [actor()], float()) -> gc_meta().
 gc_meta(Epoch, PActors, ROActors, CompactProportion) ->
-    ?GC_META{epoch=Epoch),
+    ?GC_META{epoch=Epoch,
              actor=epoch_actor(Epoch),
              primary_actors=ordsets:from_list(PActors), 
              readonly_actors=ordsets:from_list(ROActors),

--- a/src/riak_dt_withgc.erl
+++ b/src/riak_dt_withgc.erl
@@ -24,9 +24,11 @@
 -module(riak_dt_withgc).
 
 -export([new/1, value/1, value/2, update/3, merge/2, equal/2]).
+-export([gc_propose/2, gc_execute/2]).
+-export([new_epoch/1, epoch_actor/1]).
 
 -ifdef(EQC).
--include_lib("eqc/include/eqc.hrl").
+% -include_lib("eqc/include/eqc.hrl").
 % -export([gen_op/0, update_expected/3, eqc_state_value/1]).
 -endif.
 
@@ -47,10 +49,12 @@ value(#dt_withgc{mod=Mod, dt=Inner}) ->
 value(What, #dt_withgc{mod=Mod, dt=Inner}) ->
     Mod:value(What, Inner).
 
-update(How, #dt_withgc{mod=Mod, dt=Inner} = DT) ->
-    DT#dt_withgc{dt=Mod:update(How, Inner)}.
+update(How, Actor, #dt_withgc{mod=Mod, dt=Inner} = DT) ->
+    DT#dt_withgc{dt=Mod:update(How, Actor, Inner)}.
 
 % When the epochs are the same, merge inner values
+% We shoudl really check whether one DT is just a sublog of the other.
+% If it's not, we have to do some whacky shit instead.
 merge(#dt_withgc{mod=Mod, dt=Inner1, epoch=Ep1}=DT1,
       #dt_withgc{mod=Mod, dt=Inner2, epoch=Ep2}=DT2) ->
     case epoch_compare(Ep1, Ep2) of
@@ -69,13 +73,16 @@ equal(#dt_withgc{mod=Mod, dt=Inner1, epoch=Ep1},
       #dt_withgc{mod=Mod, dt=Inner2, epoch=Ep2}) ->
     epoch_compare(Ep1,Ep2) == eq andalso Mod:equal(Inner1, Inner2).
 
--spec gc_propose(term(), term()) -> {term(), tuple()}
 gc_propose(Actor, #dt_withgc{mod=Mod, dt=Inner}) ->
-    {new_epoch(Actor), Mod:gc_propose(Actor, Inner)}.
+    case Mod:gc_propose(Actor, Inner) of
+        dont_gc_me_bro -> dont_gc_me_bro;
+        GCOperation -> {?MODULE, new_epoch(Actor), GCOperation}
+    end.
 
--spec gc_execute({term(), tuple()}, term()) -> term().
-gc_execute({Epoch, Op}=GcOp,
-           #dt_withgc{mod=Mod, dt=Inner0, epoch=Ep, gc_log=Log0}=DT) ->
+gc_execute(dont_gc_me_bro, DT) ->
+    DT;
+gc_execute({?MODULE, Epoch, Op}=GcOp,
+           #dt_withgc{mod=Mod, dt=Inner0, gc_log=Log}=DT) ->
     Inner1 = Mod:gc_execute(Op, Inner0),
     Log1 = compact([GcOp | Log]),
     DT#dt_withgc{dt=Inner1, epoch=Epoch, gc_log=Log1}.
@@ -85,32 +92,45 @@ gc_execute({Epoch, Op}=GcOp,
 %         #dt_withgc{}=DT) ->
 %     DT.
 
+-ifdef(EQC).
 %% ---
 % [EQC Goes Here]
 %% ---
+-endif.
 
 
 % So this function is used by merge to get a sibling to catch up with another
 % before we can do a merge of the inner data types.
-% First we get a log of operations to perform, 
-catchup(#dt_withgc{mod=Mod, dt=Inner0, epoch=Ep, gc_log=Log}=DT, OtherLog0) ->
-    % TODO: catchup stuff goes here
-    DT.
+% Importantly we have to do the oldest GC operation first, so catchup log has the oldest one first.
+catchup(#dt_withgc{epoch=Ep}=DT0, OtherLog) ->
+    CatchupLog = prepare_catchup_log(Ep, OtherLog, []),
+    lists:foldl(fun gc_execute/2, DT0, CatchupLog).
 
-% Here we have the opportunity to get rid of old logs, or to compress them to 
+prepare_catchup_log(_Epoch, [], _CatchupLog) ->
+    throw(missing_gc_operations);
+prepare_catchup_log(Epoch, [{?MODULE, GcEpoch,_}=GcOp|Rest], CatchupLog) ->
+    case epoch_compare(Epoch, GcEpoch) of
+        lt -> prepare_catchup_log(Epoch, Rest, [GcOp|CatchupLog]);
+        eq -> CatchupLog;
+        gt -> throw(wrong_gc_order)
+    end;
+prepare_catchup_log(Epoch, [_Invalid | Rest], CatchupLog) ->
+    prepare_catchup_log(Epoch, Rest, CatchupLog).
+
+% Here we have the opportunity to get rid of old logs, or to compress them to
 % save space.
 compact(Log) ->
     Log.
 
 new_epoch(Actor) ->
     {Actor, erlang:now()}.
-    
+
 epoch_actor({Actor, _TS}) ->
     Actor.
 
-epoch_compare({_Actor1, TS1}=Epoch1, {_Actor2, TS2}=Epoch2) ->
+epoch_compare({_Actor1, TS1}=_Epoch1, {_Actor2, TS2}=_Epoch2) ->
     if
         TS1 < TS2 -> lt;
         TS1 == TS2 -> eq;
-        TS1 > TS2 -> gt;
+        TS1 > TS2 -> gt
     end.

--- a/src/riak_dt_withgc.erl
+++ b/src/riak_dt_withgc.erl
@@ -1,0 +1,116 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_dt_withgc.erl: behaviour for convergent data types that support
+%% consensus-based GC
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_dt_withgc).
+
+-export([new/1, value/1, value/2, update/3, merge/2, equal/2]).
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+% -export([gen_op/0, update_expected/3, eqc_state_value/1]).
+-endif.
+
+-record(dt_withgc, {
+    mod :: module(),    % The "type" of the inner CRDT
+    dt :: term(),       % The inner CRDT
+    gc_log = [] :: [{term(), term()}],
+                        % Operations carried out in previous GCs
+    epoch = undefined :: term()     % The id of the most recent GC
+    }).
+
+new(Mod) ->
+    #dt_withgc{mod=Mod, dt=Mod:new()}.
+
+value(#dt_withgc{mod=Mod, dt=Inner}) ->
+    Mod:value(Inner).
+
+value(What, #dt_withgc{mod=Mod, dt=Inner}) ->
+    Mod:value(What, Inner).
+
+update(How, #dt_withgc{mod=Mod, dt=Inner} = DT) ->
+    DT#dt_withgc{dt=Mod:update(How, Inner)}.
+
+% When the epochs are the same, merge inner values
+merge(#dt_withgc{mod=Mod, dt=Inner1, epoch=Ep1}=DT1,
+      #dt_withgc{mod=Mod, dt=Inner2, epoch=Ep2}=DT2) ->
+    case epoch_compare(Ep1, Ep2) of
+        % Epochs equal: just merge
+        eq -> DT1#dt_withgc{dt=Mod:merge(Inner1,Inner2)};
+        % DT1 needs to catch up with DT2 before merge
+        lt -> DT1a = catchup(DT1, DT2#dt_withgc.gc_log),
+              merge(DT1a,DT2);
+        % DT2 needs to catch up with DT1 before merge
+        gt -> DT2a = catchup(DT2, DT1#dt_withgc.gc_log),
+              merge(DT2a,DT1)
+    end.
+
+% Check epochs in the equality comparison
+equal(#dt_withgc{mod=Mod, dt=Inner1, epoch=Ep1},
+      #dt_withgc{mod=Mod, dt=Inner2, epoch=Ep2}) ->
+    epoch_compare(Ep1,Ep2) == eq andalso Mod:equal(Inner1, Inner2).
+
+-spec gc_propose(term(), term()) -> {term(), tuple()}
+gc_propose(Actor, #dt_withgc{mod=Mod, dt=Inner}) ->
+    {new_epoch(Actor), Mod:gc_propose(Actor, Inner)}.
+
+-spec gc_execute({term(), tuple()}, term()) -> term().
+gc_execute({Epoch, Op}=GcOp,
+           #dt_withgc{mod=Mod, dt=Inner0, epoch=Ep, gc_log=Log0}=DT) ->
+    Inner1 = Mod:gc_execute(Op, Inner0),
+    Log1 = compact([GcOp | Log]),
+    DT#dt_withgc{dt=Inner1, epoch=Epoch, gc_log=Log1}.
+
+%% This is only an idea right now, but could be interesting.
+% gc_undo(OldEpoch,
+%         #dt_withgc{}=DT) ->
+%     DT.
+
+%% ---
+% [EQC Goes Here]
+%% ---
+
+
+% So this function is used by merge to get a sibling to catch up with another
+% before we can do a merge of the inner data types.
+% First we get a log of operations to perform, 
+catchup(#dt_withgc{mod=Mod, dt=Inner0, epoch=Ep, gc_log=Log}=DT, OtherLog0) ->
+    % TODO: catchup stuff goes here
+    DT.
+
+% Here we have the opportunity to get rid of old logs, or to compress them to 
+% save space.
+compact(Log) ->
+    Log.
+
+new_epoch(Actor) ->
+    {Actor, erlang:now()}.
+    
+epoch_actor({Actor, _TS}) ->
+    Actor.
+
+epoch_compare({_Actor1, TS1}=Epoch1, {_Actor2, TS2}=Epoch2) ->
+    if
+        TS1 < TS2 -> lt;
+        TS1 == TS2 -> eq;
+        TS1 > TS2 -> gt;
+    end.


### PR DESCRIPTION
Just a central place to throw comments at these ideas about garbage compaction.

Flow is expected to be:
1. Work out Thresholds etc
2. check if ready for GC using `gc_ready/2`. If not ready, stop.
3. Acquire consensus (not included in this code), including making a new "epoch" somehow and electing leader
4. Leader calls `gc_propose/2` to get some kind of object that encapsulates what should be done to the CRDT
5. This object is broadcast to all replicas and they all (including the leader) call `gc_execute/2` with that object and the CRDT to actually compact.
6. Consensus is released.

Upon merge of a replica that has fallen behind with its compaction, it will first do any pending Compactions (got from the replica its trying to merge with) it hasn't already done, and then merge.
