### PR TITLE
Fragment-based GC [do not merge]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dev/*
 doc/*
 rel/riak_dt
 data/*
+.eqc-info
+current_counterexample.eqc

--- a/include/riak_dt_gc_meta.hrl
+++ b/include/riak_dt_gc_meta.hrl
@@ -1,0 +1,15 @@
+
+-type actor() :: term().
+-type epoch() :: {actor(), erlang:timestamp()}.
+
+-define(GC_META, #riak_dt_gc_meta).
+-define(GC_META_ACTOR(GM), GM?GC_META.actor).
+-record(riak_dt_gc_meta,
+        {
+          epoch :: epoch(),             % Epoch of GC
+          actor :: actor(),             % Actor performing the GC
+          primary_actors :: [actor()],  % Actors most likely to be involved in operations
+          readonly_actors :: [actor()], % Actors that can't be GCd (ie cluster remotes)
+          compact_proportion :: float()  % Max Proportion of non-primary actors or tombstones
+        }).
+-opaque gc_meta() :: #riak_dt_gc_meta{}.

--- a/include/riak_dt_gc_meta.hrl
+++ b/include/riak_dt_gc_meta.hrl
@@ -1,15 +1,13 @@
 
--type actor() :: term().
--type epoch() :: {actor(), erlang:timestamp()}.
 
 -define(GC_META, #riak_dt_gc_meta).
 -define(GC_META_ACTOR(GM), GM?GC_META.actor).
 -record(riak_dt_gc_meta,
         {
-          epoch :: epoch(),             % Epoch of GC
-          actor :: actor(),             % Actor performing the GC
-          primary_actors :: [actor()],  % Actors most likely to be involved in operations
-          readonly_actors :: [actor()], % Actors that can't be GCd (ie cluster remotes)
+          epoch :: riak_dt_gc:epoch(),             % Epoch of GC
+          actor :: riak_dt:actor(),             % Actor performing the GC
+          primary_actors :: [riak_dt:actor()],  % Actors most likely to be involved in operations
+          readonly_actors :: [riak_dt:actor()], % Actors that can't be GCd (ie cluster remotes)
           compact_threshold :: float()  % Float between 0.0 and 1.0
         }).
 -opaque gc_meta() :: #riak_dt_gc_meta{}.

--- a/include/riak_dt_gc_meta.hrl
+++ b/include/riak_dt_gc_meta.hrl
@@ -10,6 +10,28 @@
           actor :: actor(),             % Actor performing the GC
           primary_actors :: [actor()],  % Actors most likely to be involved in operations
           readonly_actors :: [actor()], % Actors that can't be GCd (ie cluster remotes)
-          compact_proportion :: float()  % Max Proportion of non-primary actors or tombstones
+          compact_threshold :: float()  % Float between 0.0 and 1.0
         }).
 -opaque gc_meta() :: #riak_dt_gc_meta{}.
+
+% A Helper, put in Calced as from the notes below. Doesn't cope with
+% 'badarith' errors, so wrap in a case statement.
+-define(SHOULD_GC(Meta,CalcedVal), CalcedVal < Meta?GC_META.compact_threshold).
+
+%% the compact_threshold is a number between 0.0 and 1.0:
+%%
+%% - closer to 0.0 means compact less often, but compact more bytes 
+%%   (ie few large compactions)
+%% - closer to 1.0 means compact more often, but compact less bytes
+%%   (ie many small compactions)
+%%
+%% We compact if a calculated value is between 0.0 and the compact_threshold
+%% (i.e. we compact as much as possible each time)
+%%
+%% For example:
+%% GCounters: Compacted when ROActors/TotalActors   < compact_threshold
+%% ORSets:    Compacted when (1 - Tombstones/Total) < compact_threshold
+%% 
+%% To make this simple, choose one of two possible calculations:
+%% * Calced = KeptSize / CurrentSize
+%% * Calced = 1 - (RemovedSize / CurrentSize)

--- a/src/riak_dt_gc.erl
+++ b/src/riak_dt_gc.erl
@@ -23,7 +23,7 @@
 -module(riak_dt_gc).
 
 -export([behaviour_info/1]).
--export([gc_meta/4]).
+-export([meta/4]).
 -export([new_epoch/1, epoch_actor/1, epoch_compare/2]).
 
 -include("riak_dt_gc_meta.hrl").
@@ -34,8 +34,8 @@ behaviour_info(callbacks) ->
      {gc_get_fragment, 2},
      {gc_replace_fragment, 3}].
 
--spec gc_meta(actor(), [actor()], [actor()], float()) -> gc_meta().
-gc_meta(Epoch, PActors, ROActors, CompactProportion) ->
+-spec meta(actor(), [actor()], [actor()], float()) -> gc_meta().
+meta(Epoch, PActors, ROActors, CompactProportion) ->
     ?GC_META{epoch=Epoch,
              actor=epoch_actor(Epoch),
              primary_actors=ordsets:from_list(PActors),

--- a/src/riak_dt_gc.erl
+++ b/src/riak_dt_gc.erl
@@ -23,7 +23,7 @@
 -module(riak_dt_gc).
 
 -export([behaviour_info/1]).
--export([meta/4]).
+-export([meta/4,meta/3]).
 -export([new_epoch/1, epoch_actor/1, epoch_compare/2]).
 
 -include("riak_dt_gc_meta.hrl").
@@ -34,13 +34,17 @@ behaviour_info(callbacks) ->
      {gc_get_fragment, 2},
      {gc_replace_fragment, 3}].
 
+-spec meta(actor(), [actor()], float()) -> gc_meta().
+meta(Epoch, PActors, CompactThreshold) ->
+    meta(Epoch, PActors, [], CompactThreshold).
+
 -spec meta(actor(), [actor()], [actor()], float()) -> gc_meta().
-meta(Epoch, PActors, ROActors, CompactProportion) ->
+meta(Epoch, PActors, ROActors, CompactThreshold) ->
     ?GC_META{epoch=Epoch,
              actor=epoch_actor(Epoch),
              primary_actors=ordsets:from_list(PActors),
              readonly_actors=ordsets:from_list(ROActors),
-             compact_proportion=CompactProportion}.
+             compact_threshold=CompactThreshold}.
 
 -spec new_epoch(actor()) -> epoch().
 new_epoch(Actor) ->

--- a/src/riak_dt_gc.erl
+++ b/src/riak_dt_gc.erl
@@ -1,0 +1,59 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_dt.erl: behaviour for convergent data types
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_dt_gc).
+
+-export([behaviour_info/1]).
+-export([gc_meta/4]).
+-export([new_epoch/1, epoch_actor/1, epoch_compare/2]).
+
+-include("riak_dt_gc_meta.hrl").
+
+behaviour_info(callbacks) ->
+    [{gc_epoch, 1},
+     {gc_ready, 2},
+     {gc_get_fragment, 2},
+     {gc_replace_fragment, 3}].
+
+-spec gc_meta(actor(), [actor()], [actor()], float()) -> gc_meta().
+gc_meta(Epoch, PActors, ROActors, CompactProportion) ->
+    ?GC_META{epoch=Epoch,
+             actor=epoch_actor(Epoch),
+             primary_actors=ordsets:from_list(PActors),
+             readonly_actors=ordsets:from_list(ROActors),
+             compact_proportion=CompactProportion}.
+
+-spec new_epoch(actor()) -> epoch().
+new_epoch(Actor) ->
+    {Actor, erlang:now()}.
+
+-spec epoch_actor(epoch()) -> actor().
+epoch_actor({Actor, _TS}) ->
+    Actor.
+
+-spec epoch_compare(epoch(), epoch()) -> lt | eq | gt.
+epoch_compare({_Actor1, TS1}=_Epoch1, {_Actor2, TS2}=_Epoch2) ->
+    if
+        TS1 < TS2 -> lt;
+        TS1 == TS2 -> eq;
+        TS1 > TS2 -> gt
+    end.

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -34,7 +34,7 @@
 
 -include("riak_dt_gc_meta.hrl").
 
--type gcounter() :: [{actor(),pos_integer()}].
+-type gcounter() :: [{riak_dt:actor(),pos_integer()}].
 -export_type([gcounter/0]).
 
 -ifdef(EQC).
@@ -110,7 +110,7 @@ gc_ready(Meta, GCnt) ->
         1 -> (GCActors > 1) or ?SHOULD_GC(Meta, ROActors/TotalActors)
     end.
 
--spec gc_epoch(gcounter()) -> epoch().
+-spec gc_epoch(gcounter()) -> riak_dt_gc:epoch().
 gc_epoch(GCnt) ->
     GCActors = [Act || {{gc, _Epoch}=Act,_Cnt} <- GCnt],
     {gc, Epoch} = hd(GCActors),

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -35,6 +35,7 @@
 -include("riak_dt_gc_meta.hrl").
 
 -type gcounter() :: [{actor(),pos_integer()}].
+-export_type([gcounter/0]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -27,8 +27,14 @@
 -module(riak_dt_gcounter).
 
 -behaviour(riak_dt).
+-behaviour(riak_dt_gc).
 
 -export([new/0, value/1, update/3, merge/2, equal/2]).
+-export([gc_epoch/1, gc_ready/2, gc_get_fragment/2, gc_replace_fragment/3]).
+
+-include("riak_dt_gc_meta.hrl").
+
+-type gcounter() :: [{actor(),pos_integer()}].
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -88,6 +94,72 @@ merge([{Actor1, Cnt1}=AC1|Rest], Clock2, Acc) ->
 
 equal(VA,VB) ->
     lists:sort(VA) =:= lists:sort(VB).
+
+%%% GC
+
+-type gc_fragment() :: gcounter().
+
+% We're ready to GC if the actors we can't compact make up more than `compact_proportion` of
+% the actors in this GCounter.
+-spec gc_ready(gc_meta(), gcounter()) -> boolean().
+gc_ready(Meta, GCnt) ->
+    GCActors = length([Act || {{gc, _Epoch}=Act,_Cnt} <- GCnt]),
+    ROActors = length(ro_actors(Meta, GCnt)),
+    TotalActors = length(GCnt),
+    Proportion = Meta?GC_META.compact_proportion,
+    (GCActors > 1) or (TotalActors * Proportion > ROActors).
+
+-spec gc_epoch(gcounter()) -> epoch().
+gc_epoch(GCnt) ->
+    GCActors = [Act || {{gc, _Epoch}=Act,_Cnt} <- GCnt],
+    {gc, Epoch} = hd(GCActors),
+    Epoch.
+
+-spec gc_get_fragment(gc_meta(), gcounter()) -> gc_fragment().
+gc_get_fragment(Meta, GCnt) ->
+    ROActors = ro_actors(Meta, GCnt),
+    DeadActors = make_fragment(ROActors, GCnt, []),
+    DeadActors.
+
+-spec gc_replace_fragment(gc_meta(), gc_fragment(), gcounter()) -> gcounter().
+gc_replace_fragment(Meta, DeadActors, GCnt0) ->
+    Epoch = Meta?GC_META.epoch,
+    {ActorAdd, GCnt1} = subtract_dead(DeadActors, GCnt0, 0),
+    GCnt2 = prune_empty_nodes(GCnt1),
+    [{{gc, Epoch},ActorAdd} | GCnt2].
+
+% Returns the actors from GCnt that we won't get rid of during compaction.
+ro_actors(Meta, GCnt) ->
+    PAs = ordsets:from_list(Meta?GC_META.primary_actors),
+    RoAs = ordsets:from_list(Meta?GC_META.readonly_actors),
+    CounterActors = ordsets:from_list([Actor || {Actor, _} <- GCnt]),
+    ordsets:intersection(ordsets:union(PAs, RoAs), CounterActors).
+
+make_fragment(_ROActors, [], Dead) ->
+    Dead;
+% Ensure previous GCs are all removed.
+make_fragment(ROActors, [{{gc, _Epoch}=Act,Cnt}|GCnt], Dead) ->
+    make_fragment(ROActors, GCnt, [{Act,Cnt}|Dead]);
+% And ensure any non-read-only actors are removed too
+make_fragment(ROActors, [{Act,Cnt}|GCnt], Dead) ->
+    case ordsets:is_element(Act, ROActors) of
+        true ->  make_fragment(ROActors, GCnt, Dead);
+        false -> make_fragment(ROActors, GCnt, [{Act,Cnt}|Dead])
+    end.
+
+subtract_dead([], GCnt, Sum) ->
+    {Sum, GCnt};
+subtract_dead([{Actor,Subtract}|Dead], GCnt, Sum) ->
+    {Ctr, NewGCnt} = case lists:keytake(Actor, 1, GCnt) of
+                        false ->
+                            {-Subtract, GCnt};
+                        {value, {_,C}, ModGCnt} ->
+                            {C-Subtract, ModGCnt}
+                     end,
+    subtract_dead(Dead, [{Actor,Ctr}|NewGCnt], Sum+Subtract).
+
+prune_empty_nodes(GCnt) ->
+    [Pair || {_,Cnt}=Pair <- GCnt, Cnt =/= 0].
 
 %% priv
 increment_by(Amount, Actor, GCnt) when is_integer(Amount), Amount > 0 ->

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -100,15 +100,15 @@ equal(VA,VB) ->
 
 -type gc_fragment() :: gcounter().
 
-% We're ready to GC if the actors we can't compact make up more than `compact_proportion` of
-% the actors in this GCounter.
 -spec gc_ready(gc_meta(), gcounter()) -> boolean().
 gc_ready(Meta, GCnt) ->
     GCActors = length([Act || {{gc, _Epoch}=Act,_Cnt} <- GCnt]),
     ROActors = length(ro_actors(Meta, GCnt)),
     TotalActors = length(GCnt),
-    Proportion = Meta?GC_META.compact_proportion,
-    (GCActors > 1) or (TotalActors * Proportion > ROActors).
+    case TotalActors of
+        0 -> false;
+        1 -> (GCActors > 1) or ?SHOULD_GC(Meta, ROActors/TotalActors)
+    end.
 
 -spec gc_epoch(gcounter()) -> epoch().
 gc_epoch(GCnt) ->

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -49,7 +49,7 @@
 -behaviour(crdt_gc_statem_eqc).
 -export([gen_op/0, gen_gc_ops/0]).
 -export([gc_model_create/0, gc_model_update/3, gc_model_merge/2, gc_model_realise/1]).
--export([gc_model_ready/2, gc_model_get_fragment/2, gc_model_replace_fragment/3]).
+-export([gc_model_ready/2]).
 -endif.
 
 %% EQC generator
@@ -257,10 +257,10 @@ gc_model_ready(Meta, {Add,Remove}) ->
         _ -> ?SHOULD_GC(Meta, 1 - (TombstoneTokens/TotalTokens))
     end.
 
-gc_model_get_fragment(_Meta, _S) ->
-    {}.
-
-gc_model_replace_fragment(_Meta, _Frag, S) ->
-    S.
+% gc_model_get_fragment(_Meta, _S) ->
+%     {}.
+% 
+% gc_model_replace_fragment(_Meta, _Frag, S) ->
+%     S.
 -endif.
 -endif.

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -43,6 +43,7 @@
 %% EQC API
 -ifdef(EQC).
 -export([gen_op/0, update_expected/3, eqc_state_value/1]).
+-compile(export_all).
 -endif.
 
 %% EQC generator
@@ -84,6 +85,27 @@ eqc_state_value({_Cnt, Dict, _L}) ->
     Remaining = sets:subtract(A, R),
     Values = [ Elem || {Elem, _X} <- sets:to_list(Remaining)],
     lists:usort(Values).
+
+%% GC Property
+
+create_gc_expected() ->
+    ordsets:new().
+
+update_gc_expected({add, X}, _Actor, State) ->
+    ordsets:add_element(X, State);
+update_gc_expected({remove, X}, _Actor, State) ->
+    ordsets:del_element(X, State).
+% update_gc_expected(_Operation, _Actor, State) ->
+%     State.
+
+merge_gc_expected(State1, State2) ->
+    ordsets:union(State1, State2).
+
+realise_gc_expected(State) ->
+    ordsets:to_list(State).
+    
+eqc_gc_ready(_S) ->
+    false.
 
 -endif.
 

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -42,7 +42,7 @@
 
 %% EQC API
 -ifdef(EQC).
--export([gen_op/0, update_expected/3, eqc_state_value/1]).
+-export([gen_op/0, gen_gc_ops/0, update_expected/3, eqc_state_value/1]).
 -compile(export_all).
 -endif.
 
@@ -51,6 +51,10 @@
 gen_op() ->
     ?LET(Add, nat(),
          oneof([{add, Add}, {remove, Add}])).
+         
+gen_gc_ops() ->
+    ?LET(Add, nat(),
+         [{add, Add}, {remove, Add}]).
 
 % gen_elems() ->
 %     ?LET(A, int(), {A, oneof([A, int()])}).

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -49,11 +49,11 @@
 %% EQC generator
 -ifdef(EQC).
 gen_op() ->
-    ?LET({Add, Remove}, gen_elems(),
+    ?LET(Add, nat(),
          oneof([{add, Add}, {remove, Remove}])).
 
-gen_elems() ->
-    ?LET(A, int(), {A, oneof([A, int()])}).
+% gen_elems() ->
+%     ?LET(A, int(), {A, oneof([A, int()])}).
 
 %% Maybe model qc state as op based?
 init_state() ->

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -91,15 +91,13 @@ eqc_state_value({_Cnt, Dict, _L}) ->
 create_gc_expected() ->
     {ordsets:new(), ordsets:new()}.
 
-update_gc_expected({add, X}, Actor, {Add,Remove}) ->
+update_gc_expected({add, Elem}, Actor, {Add,Remove}) ->
     Unique = erlang:phash2({Actor, erlang:now()}),
-    {ordsets:add_element({X, Unique}, Add), ordsets:del_element(X,Remove)};
-update_gc_expected({remove, X}, _Actor, {Add,Remove}) ->
-    ToRem = [{A,Elem} || {A,Elem} <- ordsets:to_list(Add), Elem == X],
+    {ordsets:add_element({Elem, Unique}, Add), Remove};
+update_gc_expected({remove, RemElem}, _Actor, {Add,Remove}) ->
+    ToRem = [{Elem,A} || {Elem,A} <- ordsets:to_list(Add), Elem == RemElem],
     Remove1 = ordsets:union(ordsets:from_list(ToRem),Remove),
     {Add, Remove1}.
-% update_gc_expected(_Operation, _Actor, State) ->
-%     State.
 
 merge_gc_expected({A1,R1}, {A2,R2}) ->
     A3 = ordsets:union(A1,A2),
@@ -107,7 +105,7 @@ merge_gc_expected({A1,R1}, {A2,R2}) ->
     {A3,R3}.
 
 realise_gc_expected({Add,Remove}) ->
-    Values = [ X || {X, _A} <- ordsets:to_list(ordsets:subtract(Add,Remove))],
+    Values = [ Elem || {Elem, _A} <- ordsets:to_list(ordsets:subtract(Add,Remove))],
     lists:usort(Values).
     
 eqc_gc_ready(Meta, {Add,Remove}) ->

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -50,7 +50,7 @@
 -ifdef(EQC).
 gen_op() ->
     ?LET(Add, nat(),
-         oneof([{add, Add}, {remove, Remove}])).
+         oneof([{add, Add}, {remove, Add}])).
 
 % gen_elems() ->
 %     ?LET(A, int(), {A, oneof([A, int()])}).

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -101,7 +101,7 @@ gc_ready(Meta, {Inc,Dec}) ->
     riak_dt_gcounter:gc_ready(Meta, Inc)
         orelse riak_dt_gcounter:gc_ready(Meta,Dec).
 
--spec gc_epoch(pncounter()) -> epoch().
+-spec gc_epoch(pncounter()) -> riak_dt_gc:epoch().
 gc_epoch({Inc,Dec}) ->
     Epoch = riak_dt_gcounter:gc_epoch(Inc),
     Epoch = riak_dt_gcounter:gc_epoch(Dec),

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -34,6 +34,11 @@
 
 %% API
 -export([new/0, value/1, update/3, merge/2, equal/2]).
+-export([gc_epoch/1, gc_ready/2, gc_get_fragment/2, gc_replace_fragment/3]).
+
+-include("riak_dt_gc_meta.hrl").
+
+-type pncounter() :: {riak_dt_gcounter:gcounter(),riak_dt_gcounter:gcounter()}.
 
 %% EQC API
 -ifdef(EQC).
@@ -85,6 +90,36 @@ merge({Incr1, Decr1}, {Incr2, Decr2}) ->
 
 equal({Incr1, Decr1}, {Incr2, Decr2}) ->
     riak_dt_gcounter:equal(Incr1, Incr2) andalso riak_dt_gcounter:equal(Decr1, Decr2).
+
+%%% GC
+
+-type gc_fragment() :: pncounter().
+
+% We're ready to GC if the actors we can't compact make up more than `compact_proportion` of
+% the actors in this GCounter.
+-spec gc_ready(gc_meta(), pncounter()) -> boolean().
+gc_ready(Meta, {Inc,Dec}) ->
+    riak_dt_gcounter:gc_ready(Meta, Inc)
+        orelse riak_dt_gcounter:gc_ready(Meta,Dec).
+
+-spec gc_epoch(pncounter()) -> epoch().
+gc_epoch({Inc,Dec}) ->
+    Epoch = riak_dt_gcounter:gc_epoch(Inc),
+    Epoch = riak_dt_gcounter:gc_epoch(Dec),
+    Epoch.
+
+-spec gc_get_fragment(gc_meta(), pncounter()) -> gc_fragment().
+gc_get_fragment(Meta, {Inc,Dec}) ->
+    IncFragment = riak_dt_gcounter:gc_get_fragment(Meta, Inc),
+    DecFragment = riak_dt_gcounter:gc_get_fragment(Meta, Dec),
+    {IncFragment, DecFragment}.
+
+-spec gc_replace_fragment(gc_meta(), gc_fragment(), pncounter()) -> pncounter().
+gc_replace_fragment(Meta, {IncFrag,DecFrag}, {Inc,Dec}) ->
+    Inc1 = riak_dt_gcounter:gc_replace_fragment(Meta, IncFrag, Inc),
+    Dec1 = riak_dt_gcounter:gc_replace_fragment(Meta, DecFrag, Dec),
+    {Inc1,Dec1}.
+
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -95,8 +95,7 @@ equal({Incr1, Decr1}, {Incr2, Decr2}) ->
 
 -type gc_fragment() :: pncounter().
 
-% We're ready to GC if the actors we can't compact make up more than `compact_proportion` of
-% the actors in this GCounter.
+% We're ready to GC if either of the gcounters are ready to GC.
 -spec gc_ready(gc_meta(), pncounter()) -> boolean().
 gc_ready(Meta, {Inc,Dec}) ->
     riak_dt_gcounter:gc_ready(Meta, Inc)

--- a/src/riak_dt_vvorset.erl
+++ b/src/riak_dt_vvorset.erl
@@ -81,7 +81,7 @@ gc_ready(Meta, {Add,_Remove}=VVORSet) ->
     ?SHOULD_GC(Meta, 1 - (TombstoneCount/ElementCount)).
 
 % I don't know how we find the epoch
--spec gc_epoch(vvorset()) -> epoch().
+-spec gc_epoch(vvorset()) -> riak_dt_gc:epoch().
 gc_epoch(_ORSet) ->
     {}.
 

--- a/src/riak_dt_vvorset.erl
+++ b/src/riak_dt_vvorset.erl
@@ -149,6 +149,7 @@ remove_fragment_filter(Fragment) ->
 -ifdef(TEST).
 
 -ifdef(EQC).
+-compile(export_all).
 eqc_value_test_() ->
     {timeout, 120, [?_assert(crdt_statem_eqc:prop_converge(init_state(), 1000, ?MODULE))]}.
 
@@ -188,6 +189,28 @@ eqc_state_value({_Cnt, Dict, _L}) ->
                        Dict),
     Remaining = sets:subtract(A, R),
     Values = [ Elem || {Elem, _X} <- sets:to_list(Remaining)],
+    lists:usort(Values).
+
+create_gc_expected() ->
+    {ordsets:new(), ordsets:new()}.
+
+update_gc_expected({add, X}, Actor, {Add,Remove}) ->
+    Unique = erlang:phash2({Actor, erlang:now()}),
+    {ordsets:add_element({X, Unique}, Add), ordsets:del_element(X,Remove)};
+update_gc_expected({remove, X}, _Actor, {Add,Remove}) ->
+    ToRem = [{A,Elem} || {A,Elem} <- ordsets:to_list(Add), Elem == X],
+    Remove1 = ordsets:union(ordsets:from_list(ToRem),Remove),
+    {Add, Remove1}.
+% update_gc_expected(_Operation, _Actor, State) ->
+%     State.
+
+merge_gc_expected({A1,R1}, {A2,R2}) ->
+    A3 = ordsets:union(A1,A2),
+    R3 = ordsets:union(R1,R2),
+    {A3,R3}.
+
+realise_gc_expected({Add,Remove}) ->
+    Values = [ X || {X, _A} <- ordsets:to_list(ordsets:subtract(Add,Remove))],
     lists:usort(Values).
 
 -endif.

--- a/src/riak_dt_vvorset.erl
+++ b/src/riak_dt_vvorset.erl
@@ -78,7 +78,7 @@ equal({ADict1, RDict1}, {ADict2, RDict2}) ->
 gc_ready(Meta, {Add,_Remove}=VVORSet) ->
     TombstoneCount = orddict:size(tombstones(VVORSet)),
     ElementCount   = orddict:size(Add),
-    (TombstoneCount / ElementCount) > Meta?GC_META.compact_proportion.
+    ?SHOULD_GC(Meta, 1 - (TombstoneCount/ElementCount)).
 
 % I don't know how we find the epoch
 -spec gc_epoch(vvorset()) -> epoch().

--- a/test/crdt_gc_statem_eqc.erl
+++ b/test/crdt_gc_statem_eqc.erl
@@ -81,7 +81,7 @@ gen_get_fragment(#state{mod=Mod, replicas=Replicas, gc_readies=GcReadies}) ->
 gen_meta(#state{replicas=Replicas}) ->
     Primaries = [ AId || {AId,_,_} <- lists:sublist(Replicas,1,3)],
     Epoch = riak_dt_gc:new_epoch(hd(Primaries)), % Primaries is never []
-    riak_dt_gc:meta(Epoch, Primaries, [], 1.0).
+    riak_dt_gc:meta(Epoch, Primaries, 1.0).
 
 %% Precondition, checked before command is added to the command sequence
 precondition(#state{replicas=Replicas}, {call, ?MODULE, update, [_, _, ReplicaTriple]}) ->

--- a/test/crdt_gc_statem_eqc.erl
+++ b/test/crdt_gc_statem_eqc.erl
@@ -40,6 +40,7 @@
     }).
 
 -define(NUMTESTS, 1000).
+-define(NUMCOMMANDS, 10000).
 -define(QC_OUT(P),
         eqc:on_output(fun(Str, Args) ->
                               io:format(user, Str, Args) end, P)).
@@ -128,10 +129,11 @@ postcondition(_S, {call, ?MODULE, gc_get_fragment, [Mod, Meta, {_AId, _SymbState
         true -> true;
         _    -> {postcondition_failed, "concrete state changes value when GCd", CRDTVal, PostGCCRDTVal}
     end;
-    % Get SymbFrag, apply SymbFrag to SymbState to check value doesn't change
-    % Get symbfrag, apply symbfrag to symbstate to check value stays "in step" with concfrag and concstate
-    % Apply ConcFrag to ConcState to check value doesn't change
-    % Check concfrag with symbstate
+    % Four Options (* is the one done above)
+    % - Get SymbFrag, apply SymbFrag to SymbState to check value doesn't change
+    % - Get symbfrag, apply symbfrag to symbstate to check value stays "in step" with concfrag and concstate
+    % * Apply ConcFrag to ConcState to check value doesn't change
+    % - Check concfrag with symbstate
 
 postcondition(_S,_Command,_CommandRes) ->
     true.
@@ -173,11 +175,11 @@ next_state(S, _V, _Command) ->
 %%% Properties
 
 prop_gc_correct(Mod) ->
-    ?FORALL(Cmds,more_commands(10,commands(?MODULE,#state{mod=Mod})),
+    ?FORALL(Cmds,more_commands(?NUMCOMMANDS,commands(?MODULE,#state{mod=Mod})),
         begin
             Res={_,_,Result} = run_commands(?MODULE, Cmds),
             aggregate(command_names(Cmds),
-                      pretty_commands(?MODULE, Cmds, Res, Result == ok))
+                      pretty_commands(?MODULE, Cmds, Res, eqc_statem:show_states(Result == ok)))
         end).
 
 

--- a/test/crdt_gc_statem_eqc.erl
+++ b/test/crdt_gc_statem_eqc.erl
@@ -69,7 +69,7 @@ command(State=#state{mod=Mod, replicas=Replicas, gc_readies=GcReadies}) ->
                 [{1, {call, ?MODULE, merge,  [Mod, elements(Replicas), elements(Replicas)]}} || length(Replicas) > 0] ++
                 [{10, {call, ?MODULE, gc_ready, [Mod, gen_meta(State), elements(Replicas)]}} || length(Replicas) > 0]
              );
-        _ -> return({call, ?MODULE, gc_get_fragment, gen_get_fragment(State)})
+        _ -> gen_get_fragment(State)
     end.
 
 
@@ -78,7 +78,8 @@ gen_get_fragment(#state{mod=Mod, replicas=Replicas, gc_readies=GcReadies}) ->
          elements(orddict:to_list(GcReadies)),
          begin
              ReplicaTriple = {AId,_,_} = lists:keyfind(AId,1,Replicas),
-             [Mod, Meta, ReplicaTriple]
+             io:format("G"),
+             {call, ?MODULE, gc_get_fragment, [Mod, Meta, ReplicaTriple]}
          end).
 
 gen_meta(#state{replicas=Replicas}) ->
@@ -93,8 +94,8 @@ precondition(#state{replicas=Replicas}, {call, ?MODULE, merge, [_, ReplicaTriple
     lists:member(ReplicaTriple1, Replicas) andalso lists:member(ReplicaTriple2, Replicas);
 precondition(#state{replicas=Replicas}, {call, ?MODULE, gc_ready, [_, _, ReplicaTriple]}) ->
     lists:member(ReplicaTriple, Replicas);
-precondition(#state{gc_readies=GcReadies}, {call, ?MODULE, gc_get_fragment, [_Mod, _Meta, {AId, _SymbState, _CRDTState}]}) ->
-    orddict:is_key(AId, GcReadies);
+% precondition(#state{gc_readies=GcReadies}, {call, ?MODULE, gc_get_fragment, [_Mod, _Meta, {AId, _SymbState, _CRDTState}]}) ->
+%     orddict:is_key(AId, GcReadies);
 precondition(_S,_Command) ->
     true.
 

--- a/test/crdt_gc_statem_eqc.erl
+++ b/test/crdt_gc_statem_eqc.erl
@@ -40,7 +40,8 @@
     }).
 
 -define(NUMTESTS, 1000).
--define(NUMCOMMANDS, 10000).
+-define(NUMCOMMANDS, 10).
+-define(BATCHSIZE, 100).
 -define(QC_OUT(P),
         eqc:on_output(fun(Str, Args) ->
                               io:format(user, Str, Args) end, P)).
@@ -65,20 +66,29 @@ command(State=#state{mod=Mod, replicas=Replicas, gc_readies=GcReadies}) ->
     case orddict:size(GcReadies) of
         0 -> frequency(
                 [{1, {call, ?MODULE, create, [Mod]}}] ++
-                [{10, {call, ?MODULE, update, [Mod, Mod:gen_op(), elements(Replicas)]}} || length(Replicas) > 0] ++
-                [{1, {call, ?MODULE, merge,  [Mod, elements(Replicas), elements(Replicas)]}} || length(Replicas) > 0] ++
-                [{10, {call, ?MODULE, gc_ready, [Mod, gen_meta(State), elements(Replicas)]}} || length(Replicas) > 0]
+                [{10, gen_update(State)} || length(Replicas) > 0] ++
+                [{10, {call, ?MODULE, update, [Mod, Mod:gen_gc_ops(), elements(Replicas)]}} || length(Replicas) > 0] ++
+                [{10, {call, ?MODULE, merge,  [Mod, elements(Replicas), elements(Replicas)]}} || length(Replicas) > 0] ++
+                [{5, {call, ?MODULE, gc_ready, [Mod, gen_meta(State), elements(Replicas)]}} || length(Replicas) > 0]
              );
-        _ -> gen_get_fragment(State)
+        _ -> frequency(
+                [{10, gen_update(State)} || length(Replicas) > 0] ++
+                [{10, gen_get_fragment(State)}]
+                % call gc_replace_fragment
+            )
+        gen_get_fragment(State)
     end.
 
+gen_update(#state{mod=Mod,replicas=Replicas}) ->
+    ?LET(Operations,
+         shrink_list(lists:duplicate(?BATCHSIZE,Mod:gen_op())),
+         {call, ?MODULE, update, [Mod, Operations, elements(Replicas)]}).
 
 gen_get_fragment(#state{mod=Mod, replicas=Replicas, gc_readies=GcReadies}) ->
     ?LET({AId,Meta},
          elements(orddict:to_list(GcReadies)),
          begin
              ReplicaTriple = {AId,_,_} = lists:keyfind(AId,1,Replicas),
-             io:format("G"),
              {call, ?MODULE, gc_get_fragment, [Mod, Meta, ReplicaTriple]}
          end).
 
@@ -88,21 +98,22 @@ gen_meta(#state{replicas=Replicas}) ->
     riak_dt_gc:meta(Epoch, Primaries, [], 1.0).
 
 %% Precondition, checked before command is added to the command sequence
-precondition(#state{replicas=Replicas}, {call, ?MODULE, update, [_, _, ReplicaTriple]}) ->
+precondition(#state{replicas=Replicas}, {call, ?MODULE, update, [_,_,ReplicaTriple]}) ->
     lists:member(ReplicaTriple, Replicas);
 precondition(#state{replicas=Replicas}, {call, ?MODULE, merge, [_, ReplicaTriple1, ReplicaTriple2]}) ->
     lists:member(ReplicaTriple1, Replicas) andalso lists:member(ReplicaTriple2, Replicas);
 precondition(#state{replicas=Replicas}, {call, ?MODULE, gc_ready, [_, _, ReplicaTriple]}) ->
     lists:member(ReplicaTriple, Replicas);
-% precondition(#state{gc_readies=GcReadies}, {call, ?MODULE, gc_get_fragment, [_Mod, _Meta, {AId, _SymbState, _CRDTState}]}) ->
-%     orddict:is_key(AId, GcReadies);
+precondition(#state{gc_readies=GcReadies,replicas=Replicas}, 
+            {call, ?MODULE, gc_get_fragment, [_Mod, _Meta, ReplicaTriple={AId, _SymbState, _CRDTState}]}) ->
+    lists:member(ReplicaTriple, Replicas) andalso orddict:is_key(AId, GcReadies);
 precondition(_S,_Command) ->
     true.
 
 %% Postcondition, checked after command has been evaluated
-postcondition(_S, {call, ?MODULE, update, [Mod, Operation, {AId, SymbState, _}]}, Updated) ->
+postcondition(_S, {call, ?MODULE, update, [Mod, Operations, {AId, SymbState, _}]}, Updated) ->
     CRDTVal = value(Mod,Updated),
-    SymbState1 = Mod:update_gc_expected(Operation, AId, SymbState),
+    SymbState1 = apply_operations(AId, Operations, SymbState, fun Mod:update_gc_expected/3),
     SymbVal = Mod:realise_gc_expected(SymbState1),
     case values_equal(CRDTVal, SymbVal) of
         true -> true;
@@ -147,10 +158,10 @@ next_state(State = #state{replicas=Replicas, actor_id=AId}, V, {call, ?MODULE, c
     Replicas1 = [{AId, Mod:create_gc_expected(), V} | Replicas],
     State#state{replicas=Replicas1, actor_id=AId+1};
 
-next_state(State = #state{replicas=Replicas}, V, {call, ?MODULE, update, [Mod, Operation, {AId, SymbState, _DynamicState}]}) ->
+next_state(State = #state{replicas=Replicas}, V, {call, ?MODULE, update, [Mod, Operations, {AId, SymbState, _DynamicState}]}) ->
     {value, _, Replicas1} = lists:keytake(AId, 1, Replicas),
-    NewVal = {AId, Mod:update_gc_expected(Operation, AId, SymbState), V},
-    State#state{replicas=[NewVal|Replicas1]};
+    SymbState1 = apply_operations(AId, Operations, SymbState, fun Mod:update_gc_expected/3),
+    State#state{replicas=[{AId, SymbState1, V}|Replicas1]};
 
 next_state(State = #state{replicas=Replicas}, V,
            {call, ?MODULE, merge, [Mod, {AId1, SymbState1, _DS1}, {_AId2, SymbState2, _DS2}]}) ->
@@ -203,8 +214,8 @@ commands_sampler(Mod) ->
 create(Module) ->
     Module:new().
 
-update(Module, Operation, {Actor,_SymbState,CRDT}) ->
-    Module:update(Operation,Actor,CRDT).
+update(Module, Operations, {Actor,_SymbState,CRDT}) ->
+    apply_operations(Actor, Operations, CRDT, fun Module:update/3).
 
 merge(Module, {_,_,CRDT1},{_,_,CRDT2}) ->
     Module:merge(CRDT1, CRDT2).
@@ -223,6 +234,11 @@ equal(Module, CRDT1, CRDT2) ->
 
 replace_fragment(Module, Meta, CRDTFrag, CRDT) ->
     Module:gc_replace_fragment(Meta, CRDTFrag, CRDT).
+
+apply_operations(Actor,Operations,Data,Function) ->
+    lists:foldl(fun(Operation,Data1) ->
+            Function(Operation,Actor,Data1)
+        end, Data, Operations).
 
 %%% Priv
 

--- a/test/crdt_gc_statem_eqc.erl
+++ b/test/crdt_gc_statem_eqc.erl
@@ -28,6 +28,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -compile(export_all).
+-behaviour(eqc_statem).
+-export([initial_state/0, command/1, precondition/2, next_state/3, postcondition/3]).
 
 -record(state,{
     mod, % Module Under Test

--- a/test/crdt_gc_statem_eqc.erl
+++ b/test/crdt_gc_statem_eqc.erl
@@ -157,7 +157,7 @@ next_state(State = #state{gc_readies=GcReadies}, _V,
            {call, ?MODULE, gc_ready, [Mod, Meta, {AId, SymbState, _DynamicState}]}) ->
     SymbReady = Mod:eqc_gc_ready(Meta, SymbState),
     GcReadies1 = case SymbReady of
-                    true -> orddict:insert(AId, Meta);
+                    true -> orddict:store(AId, Meta, GcReadies);
                     _    -> GcReadies
                  end,
     State#state{gc_readies=GcReadies1};

--- a/test/crdt_gc_statem_eqc.erl
+++ b/test/crdt_gc_statem_eqc.erl
@@ -97,7 +97,7 @@ postcondition(_S, {call, ?MODULE, update, [Mod, Operation, {AId, SymbState, _}]}
     SymbVal = Mod:realise_gc_expected(SymbState1),
     case values_equal(CRDTVal, SymbVal) of
         true -> true;
-        _    -> {postcondition_failed, "SymbVal does not look like CRDTVal", SymbVal, CRDTVal}
+        _    -> {postcondition_failed, "The Symbolic Value seems to have deviated from the CRDT Value", SymbVal, CRDTVal}
     end;
 
 postcondition(_S, {call, ?MODULE, merge, [Mod, ReplicaTriple1, ReplicaTriple2]}, Merged1) ->
@@ -106,7 +106,7 @@ postcondition(_S, {call, ?MODULE, merge, [Mod, ReplicaTriple1, ReplicaTriple2]},
     Merged2 = merge(Mod, ReplicaTriple2, ReplicaTriple1),
     case equal(Mod, Merged1, Merged2) of
         true -> true;
-        _    -> {postcondition_failed, "Merge is not commutative", Merged1, Merged2}
+        _    -> {postcondition_failed, "merge/2 is not commutative (in the eyes of equals/2)", Merged1, Merged2}
     end;
 
 postcondition(_S,_Command,_CommandRes) ->

--- a/test/crdt_gc_statem_eqc.erl
+++ b/test/crdt_gc_statem_eqc.erl
@@ -35,7 +35,8 @@
     mod, % Module Under Test
     actor_id = 0, % Current Actor
     replicas = [], % List of replicas
-    fragments = [] % Log of fragments to catchup
+    fragments = [], % Log of fragments to catchup
+    gc_readies = orddict:new() % Orddict full of actors ready to GC
     }).
 
 -define(NUMTESTS, 1000).
@@ -43,32 +44,53 @@
         eqc:on_output(fun(Str, Args) ->
                               io:format(user, Str, Args) end, P)).
 
+%%% Statem Callbacks
+
 %% Initialize the state
 initial_state() ->
     #state{}.
 
 %% Command generator, S is the state
-command(#state{mod=Mod, replicas=Replicas}) ->
-    % - Create Replica
-    % - Update Replica
-    % - Merging 2 Replicas
+command(State=#state{mod=Mod, replicas=Replicas, gc_readies=GcReadies}) ->
+    % - Create Replica (Y)
+    % - Update Replica (Y)
+    % - Merging 2 Replicas (Y)
     % ----
     % - GC Ready?
     % - Proposing a GC (getting a fragment)
     % - Exectuting a GC (removing the fragment from a given replica)
     %  - Execute a GC immediately that it's proposed
     %  - Execute sometime later
-    oneof(
-        [{call, ?MODULE, create, [Mod]}] ++
-        [{call, ?MODULE, update, [Mod, Mod:gen_op(), elements(Replicas)]} || length(Replicas) > 0] ++
-        [{call, ?MODULE, merge,  [Mod, elements(Replicas), elements(Replicas)]} || length(Replicas) > 0]
+    frequency(
+        [{1, {call, ?MODULE, create, [Mod]}}] ++
+        [{10, {call, ?MODULE, update, [Mod, Mod:gen_op(), elements(Replicas)]}} || length(Replicas) > 0] ++
+        [{1, {call, ?MODULE, merge,  [Mod, elements(Replicas), elements(Replicas)]}} || length(Replicas) > 0] ++
+        [{10, {call, ?MODULE, gc_ready, [Mod, gen_meta(State), elements(Replicas)]}} || length(Replicas) > 0] ++
+        [{10, {call, ?MODULE, gc_get_fragment, gen_get_fragment(State)}} || orddict:size(GcReadies) > 0]
     ).
+
+gen_get_fragment(#state{mod=Mod, replicas=Replicas, gc_readies=GcReadies}) ->
+    ?LET({AId,Meta},
+         elements(orddict:to_list(GcReadies)),
+         begin
+             ReplicaTriple = {AId,_,_} = lists:keyfind(AId,1,Replicas),
+             [Mod, Meta, ReplicaTriple]
+         end).
+
+gen_meta(#state{replicas=Replicas}) ->
+    Primaries = [ AId || {AId,_,_} <- lists:sublist(Replicas,1,3)],
+    Epoch = riak_dt_gc:new_epoch(hd(Primaries)), % Primaries is never []
+    riak_dt_gc:meta(Epoch, Primaries, [], 1.0).
 
 %% Precondition, checked before command is added to the command sequence
 precondition(#state{replicas=Replicas}, {call, ?MODULE, update, [_, _, ReplicaTriple]}) ->
     lists:member(ReplicaTriple, Replicas);
 precondition(#state{replicas=Replicas}, {call, ?MODULE, merge, [_, ReplicaTriple1, ReplicaTriple2]}) ->
     lists:member(ReplicaTriple1, Replicas) andalso lists:member(ReplicaTriple2, Replicas);
+precondition(#state{replicas=Replicas}, {call, ?MODULE, gc_ready, [_, _, ReplicaTriple]}) ->
+    lists:member(ReplicaTriple, Replicas);
+precondition(#state{gc_readies=GcReadies}, {call, ?MODULE, gc_get_fragment, [_Mod, _Meta, {AId, _SymbState, _CRDTState}]}) ->
+    orddict:is_key(AId, GcReadies);
 precondition(_S,_Command) ->
     true.
 
@@ -91,6 +113,26 @@ postcondition(_S, {call, ?MODULE, merge, [Mod, ReplicaTriple1, ReplicaTriple2]},
         _    -> {postcondition_failed, "merge/2 is not commutative (in the eyes of equals/2)", Merged1, Merged2}
     end;
 
+postcondition(_S, {call, ?MODULE, gc_ready, [Mod, Meta, {_AId, SymbState, _}]}, CRDTReady) ->
+    SymbReady = Mod:eqc_gc_ready(Meta, SymbState),
+    case SymbReady =:= CRDTReady of
+        true -> true;
+        _    -> {postcondition_failed, "eqc_gc_ready/2 does not agree with gc_ready/2", SymbReady, CRDTReady}
+    end;
+
+postcondition(_S, {call, ?MODULE, gc_get_fragment, [Mod, Meta, {_AId, _SymbState, CRDTState}]}, CRDTFragment) ->
+    CRDTVal = value(Mod, CRDTState),
+    PostGCCRDT = replace_fragment(Mod, Meta, CRDTFragment, CRDTState),
+    PostGCCRDTVal = value(Mod, PostGCCRDT),
+    case values_equal(CRDTVal, PostGCCRDTVal) of
+        true -> true;
+        _    -> {postcondition_failed, "concrete state changes value when GCd", CRDTVal, PostGCCRDTVal}
+    end;
+    % Get SymbFrag, apply SymbFrag to SymbState to check value doesn't change
+    % Get symbfrag, apply symbfrag to symbstate to check value stays "in step" with concfrag and concstate
+    % Apply ConcFrag to ConcState to check value doesn't change
+    % Check concfrag with symbstate
+
 postcondition(_S,_Command,_CommandRes) ->
     true.
 
@@ -99,27 +141,47 @@ next_state(State = #state{replicas=Replicas, actor_id=AId}, V, {call, ?MODULE, c
     Replicas1 = [{AId, Mod:create_gc_expected(), V} | Replicas],
     State#state{replicas=Replicas1, actor_id=AId+1};
 
-next_state(State = #state{replicas=Replicas}, V, {call, ?MODULE, update, [Mod, Operation, {AId, SymbState, _ConcreteState}]}) ->
+next_state(State = #state{replicas=Replicas}, V, {call, ?MODULE, update, [Mod, Operation, {AId, SymbState, _DynamicState}]}) ->
     {value, _, Replicas1} = lists:keytake(AId, 1, Replicas),
     NewVal = {AId, Mod:update_gc_expected(Operation, AId, SymbState), V},
     State#state{replicas=[NewVal|Replicas1]};
 
 next_state(State = #state{replicas=Replicas}, V,
-           {call, ?MODULE, merge, [Mod, {AId1, SymbState1, _CS1}, {_AId2, SymbState2, _CS2}]}) ->
+           {call, ?MODULE, merge, [Mod, {AId1, SymbState1, _DS1}, {_AId2, SymbState2, _DS2}]}) ->
     {value, _, Replicas1} = lists:keytake(AId1, 1, Replicas),
     MergedSymbState = Mod:merge_gc_expected(SymbState1, SymbState2),
     NewVal = {AId1, MergedSymbState, V},
     State#state{replicas=[NewVal|Replicas1]};
 
+next_state(State = #state{gc_readies=GcReadies}, _V,
+           {call, ?MODULE, gc_ready, [Mod, Meta, {AId, SymbState, _DynamicState}]}) ->
+    SymbReady = Mod:eqc_gc_ready(Meta, SymbState),
+    GcReadies1 = case SymbReady of
+                    true -> orddict:insert(AId, Meta);
+                    _    -> GcReadies
+                 end,
+    State#state{gc_readies=GcReadies1};
+
+next_state(State=#state{fragments=Fragments}, Fragment,
+           {call, ?MODULE, gc_get_fragment, [Mod, Meta, {_AId, SymbState, _DS}]}) ->
+    SymbFrag = Mod:eqc_gc_get_fragment(Meta, SymbState),
+    State#state{fragments=[{Meta,SymbFrag,Fragment}|Fragments]};
+
 next_state(S, _V, _Command) ->
     S.
 
+%%% Properties
+
 prop_gc_correct(Mod) ->
-    ?FORALL(Cmds,commands(?MODULE,#state{mod=Mod}),
+    ?FORALL(Cmds,more_commands(10,commands(?MODULE,#state{mod=Mod})),
         begin
             Res={_,_,Result} = run_commands(?MODULE, Cmds),
-            pretty_commands(?MODULE, Cmds, Res, Result == ok)
+            aggregate(command_names(Cmds),
+                      pretty_commands(?MODULE, Cmds, Res, Result == ok))
         end).
+
+
+%%% Callbacks Used Above
 
 create(Module) ->
     Module:new().
@@ -130,16 +192,27 @@ update(Module, Operation, {Actor,_SymbState,CRDT}) ->
 merge(Module, {_,_,CRDT1},{_,_,CRDT2}) ->
     Module:merge(CRDT1, CRDT2).
 
+gc_ready(Module, Meta, {_,_,CRDT}) ->
+    Module:gc_ready(Meta, CRDT).
+
+gc_get_fragment(Module, Meta, {_,_,CRDT}) ->
+    Module:gc_get_fragment(Meta,CRDT).
+
 value(Module, CRDT) ->
     Module:value(CRDT).
+
+equal(Module, CRDT1, CRDT2) ->
+    Module:equal(CRDT1, CRDT2) andalso Module:equal(CRDT2, CRDT1).
+
+replace_fragment(Module, Meta, CRDTFrag, CRDT) ->
+    Module:gc_replace_fragment(Meta, CRDTFrag, CRDT).
+
+%%% Priv
 
 values_equal(A,B) when is_list(A) ->
     lists:sort(A) == lists:sort(B);
 values_equal(A,B) ->
     A == B.
-
-equal(Module, CRDT1, CRDT2) ->
-    Module:equal(CRDT1, CRDT2) andalso Module:equal(CRDT2, CRDT1).
 
 
 -endif. % EQC

--- a/test/crdt_gc_statem_eqc.erl
+++ b/test/crdt_gc_statem_eqc.erl
@@ -1,0 +1,143 @@
+%% -------------------------------------------------------------------
+%%
+%% crdt_gc_statem_eqc: Quickcheck statem test for riak_dt_gc modules
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(crdt_gc_statem_eqc).
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_statem.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+-record(state,{
+    mod, % Module Under Test
+    actor_id = 0, % Current Actor
+    replicas = [], % List of replicas
+    fragments = [] % Log of fragments to catchup
+    }).
+
+-define(NUMTESTS, 1000).
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) ->
+                              io:format(user, Str, Args) end, P)).
+
+%% Initialize the state
+initial_state() ->
+    #state{}.
+
+%% Command generator, S is the state
+command(#state{mod=Mod, replicas=Replicas}) ->
+    % - Create Replica
+    % - Update Replica
+    % - Merging 2 Replicas
+    % ----
+    % - GC Ready?
+    % - Proposing a GC (getting a fragment)
+    % - Exectuting a GC (removing the fragment from a given replica)
+    %  - Execute a GC immediately that it's proposed
+    %  - Execute sometime later
+    oneof(
+        [{call, ?MODULE, create, [Mod]}] ++
+        [{call, ?MODULE, update, [Mod, Mod:gen_op(), elements(Replicas)]} || length(Replicas) > 0] ++
+        [{call, ?MODULE, merge,  [Mod, elements(Replicas), elements(Replicas)]} || length(Replicas) > 0]
+    ).
+
+%% Precondition, checked before command is added to the command sequence
+precondition(#state{replicas=Replicas}, {call, ?MODULE, update, [_, _, ReplicaTriple]}) ->
+    lists:member(ReplicaTriple, Replicas);
+precondition(#state{replicas=Replicas}, {call, ?MODULE, merge, [_, ReplicaTriple1, ReplicaTriple2]}) ->
+    lists:member(ReplicaTriple1, Replicas) andalso lists:member(ReplicaTriple2, Replicas);
+precondition(_S,_Command) ->
+    true.
+
+%% Next state transformation, S is the current state
+next_state(State = #state{replicas=Replicas, actor_id=AId}, V, {call, ?MODULE, create, [Mod]}) ->
+    Replicas1 = [{AId, Mod:create_gc_expected(), V} | Replicas],
+    State#state{replicas=Replicas1, actor_id=AId+1};
+
+next_state(State = #state{replicas=Replicas}, V, {call, ?MODULE, update, [Mod, Operation, {AId, SymbState, _ConcreteState}]}) ->
+    {value, _, Replicas1} = lists:keytake(AId, 1, Replicas),
+    NewVal = {AId, Mod:update_gc_expected(Operation, AId, SymbState), V},
+    State#state{replicas=[NewVal|Replicas1]};
+
+next_state(State = #state{replicas=Replicas}, V,
+           {call, ?MODULE, merge, [Mod, {AId1, SymbState1, _CS1}, {_AId2, SymbState2, _CS2}]}) ->
+    {value, _, Replicas1} = lists:keytake(AId1, 1, Replicas),
+    MergedSymbState = Mod:merge_gc_expected(SymbState1, SymbState2),
+    NewVal = {AId1, MergedSymbState, V},
+    State#state{replicas=[NewVal|Replicas1]};
+
+next_state(S, _V, _Command) ->
+    S.
+
+%% Postcondition, checked after command has been evaluated
+postcondition(_S, {call, ?MODULE, update, [Mod, Operation, {AId, SymbState, _}]}, Updated) ->
+    CRDTVal = value(Mod,Updated),
+    SymbState1 = Mod:update_gc_expected(Operation, AId, SymbState),
+    SymbVal = Mod:realise_gc_expected(SymbState1),
+    case values_equal(CRDTVal, SymbVal) of
+        true -> true;
+        _    -> {postcondition_failed, "SymbVal does not look like CRDTVal", SymbVal, CRDTVal}
+    end;
+
+postcondition(_S, {call, ?MODULE, merge, [Mod, ReplicaTriple1, ReplicaTriple2]}, Merged1) ->
+    % In operation ?MODULE:merge, ReplicaTriple1 is merged with ReplicaTriple2.
+    % Let's do it the opposite way around to check commutativity
+    Merged2 = merge(Mod, ReplicaTriple2, ReplicaTriple1),
+    case equal(Mod, Merged1, Merged2) of
+        true -> true;
+        _    -> {postcondition_failed, "Merge is not commutative", Merged1, Merged2}
+    end;
+
+postcondition(_S,_Command,_CommandRes) ->
+    true.
+
+prop_gc_correct(Mod) ->
+    ?FORALL(Cmds,commands(?MODULE,#state{mod=Mod}),
+        begin
+            Res={_,_,Result} = run_commands(?MODULE, Cmds),
+            pretty_commands(?MODULE, Cmds, Res, Result == ok)
+        end).
+
+create(Module) ->
+    Module:new().
+
+update(Module, Operation, {Actor,_SymbState,CRDT}) ->
+    Module:update(Operation,Actor,CRDT).
+
+merge(Module, {_,_,CRDT1},{_,_,CRDT2}) ->
+    Module:merge(CRDT1, CRDT2).
+
+value(Module, CRDT) ->
+    Module:value(CRDT).
+
+values_equal(A,B) when is_list(A) ->
+    lists:sort(A) == lists:sort(B);
+values_equal(A,B) ->
+    A == B.
+
+equal(Module, CRDT1, CRDT2) ->
+    Module:equal(CRDT1, CRDT2) andalso Module:equal(CRDT2, CRDT1).
+
+
+-endif. % EQC


### PR DESCRIPTION
Taking all the good ideas from #45 and essentially starting again.

Flow is expected to be:
1. Work out Thresholds etc, for the meta-object (this includes making a new epoch, maybe)
2. check if ready for GC using `gc_ready/2`. If not ready, stop.
3. Acquire consensus (not included in this code), including electing leader
4. Leader calls `gc_get_fragment/2` to get the fragment of the CRDT that should be removed (for saving somewhere else)
5. This fragment is broadcast to all replicas and they all (including the leader) call `gc_replace_fragment/3` with that object and the CRDT. This is the compaction step.
6. Consensus is released.

The meta object contains data on primary actors, readonly actors (cluster remote views), epoch, and a threshold of how many actors are allowed compared to the number of primary+readonly actors. 

I'm going to close #45, but the ideas are still in my head.
