### PR TITLE
Dialyzer fixes

### DIFF
--- a/src/orset_bm.erl
+++ b/src/orset_bm.erl
@@ -21,7 +21,7 @@
 start(Cmds, Mod) ->
     TS = erlang:now(),
     Coord =  start_coordinator(?N, Mod, self()),
-    [start_proc(I, Cmds, Mod, Coord) || I <- lists:seq(1, ?N)],
+    [_|_] = [start_proc(I, Cmds, Mod, Coord) || I <- lists:seq(1, ?N)],
 
     receive
         {Coord, Results} ->
@@ -100,7 +100,7 @@ perform(remove, {I, Mod, Val0, AL0}) ->
 perform(merge, {I, Mod, Val0, AL0}) ->
     Peer = crypto:rand_uniform(1, ?N),
     PeerName = list_to_atom(integer_to_list(Peer)),
-    case whereis(PeerName) of
+    _ = case whereis(PeerName) of
         Pid when is_pid(Pid) ->
             Pid ! {merge, self(),  Val0};
         _ -> ok

--- a/src/riak_dt.erl
+++ b/src/riak_dt.erl
@@ -22,24 +22,26 @@
 
 -module(riak_dt).
 
--export([behaviour_info/1]).
+-type crdt() :: term().
+-type operation() :: term().
+-type actor() :: term().
 
--ifndef(EQC).
--define(EQC_DT_CALLBACKS, []).
--else.
+-callback new() -> crdt().
+-callback value(crdt()) -> term().
+-callback value(term(), crdt()) -> term().
+-callback update(operation(), actor(), crdt()) -> crdt().
+-callback merge(crdt(), crdt()) -> crdt().
+-callback equal(crdt(), crdt()) -> boolean().
+-callback to_binary(crdt()) -> binary().
+-callback from_binary(binary()) -> crdt().
+
+-ifdef(EQC).
 % Extra callbacks for any crdt_statem_eqc tests
--define(EQC_DT_CALLBACKS, [{gen_op, 0}, 
-                           {update_expected, 3}, 
-                           {eqc_state_value, 1}, 
-                           {init_state, 0}]).
--endif.
+-type model_state() :: term().
 
-behaviour_info(callbacks) ->
-    [{new, 0},
-     {value, 1},
-     {value, 2},
-     {update, 3},
-     {merge, 2},
-     {equal, 2},
-     {to_binary, 1},
-     {from_binary, 1} | ?EQC_DT_CALLBACKS ].
+-callback gen_op() -> eqc_gen:gen(operation()).
+-callback update_expected(actor(), operation(), model_state()) -> model_state().
+-callback eqc_state_value(model_state()) -> term().
+-callback init_state() -> model_state().
+
+-endif.

--- a/src/riak_dt.erl
+++ b/src/riak_dt.erl
@@ -22,6 +22,8 @@
 
 -module(riak_dt).
 
+-export_type([actor/0]).
+
 -type crdt() :: term().
 -type operation() :: term().
 -type actor() :: term().

--- a/src/riak_dt_disable_flag.erl
+++ b/src/riak_dt_disable_flag.erl
@@ -29,7 +29,7 @@
 
 -behaviour(riak_dt).
 
--export([new/0, value/1, update/3, merge/2, equal/2]).
+-export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -54,10 +54,15 @@ eqc_state_value(S) ->
     S.
 -endif.
 
+-define(TAG, 80).
+
 new() ->
     on.
 
 value(Flag) ->
+    Flag.
+
+value(_, Flag) ->
     Flag.
 
 update(disable, _Actor, _Flag) ->
@@ -68,6 +73,12 @@ merge(FA, FB) ->
 
 equal(FA,FB) ->
     FA =:= FB.
+
+from_binary(<<?TAG:7, 0:1>>) -> off;
+from_binary(<<?TAG:7, 1:1>>) -> on.
+
+to_binary(off) -> <<?TAG:7, 0:1>>;
+to_binary(on) -> <<?TAG:7, 1:1>>.
 
 %% priv
 flag_and(on, on) ->

--- a/src/riak_dt_disable_flag.erl
+++ b/src/riak_dt_disable_flag.erl
@@ -33,7 +33,7 @@
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--export([gen_op/0, update_expected/3, eqc_state_value/1]).
+-export([gen_op/0, init_state/0, update_expected/3, eqc_state_value/1]).
 -endif.
 
 -ifdef(TEST).
@@ -42,6 +42,9 @@
 
 %% EQC generator
 -ifdef(EQC).
+init_state() ->
+    on.
+
 gen_op() ->
     disable.
 
@@ -96,7 +99,7 @@ flag_and(_, off) ->
 
 -ifdef(EQC).
 eqc_value_test_() ->
-    {timeout, 120, [?_assert(crdt_statem_eqc:prop_converge(on, 1000, ?MODULE))]}.
+    crdt_statem_eqc:run(?MODULE, 1000).
 -endif.
 
 new_test() ->

--- a/src/riak_dt_enable_flag.erl
+++ b/src/riak_dt_enable_flag.erl
@@ -33,7 +33,7 @@
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--export([gen_op/0, update_expected/3, eqc_state_value/1]).
+-export([gen_op/0, init_state/0, update_expected/3, eqc_state_value/1]).
 -endif.
 
 -ifdef(TEST).
@@ -42,6 +42,9 @@
 
 %% EQC generator
 -ifdef(EQC).
+init_state() -> 
+    off.    
+
 gen_op() ->
     enable.
 
@@ -96,7 +99,7 @@ flag_or(off, off) ->
 
 -ifdef(EQC).
 eqc_value_test_() ->
-    {timeout, 120, [?_assert(crdt_statem_eqc:prop_converge(off, 1000, ?MODULE))]}.
+    crdt_statem_eqc:run(?MODULE, 1000).
 -endif.
 
 new_test() ->

--- a/src/riak_dt_enable_flag.erl
+++ b/src/riak_dt_enable_flag.erl
@@ -29,7 +29,7 @@
 
 -behaviour(riak_dt).
 
--export([new/0, value/1, update/3, merge/2, equal/2]).
+-export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -54,10 +54,15 @@ eqc_state_value(S) ->
     S.
 -endif.
 
+-define(TAG, 79).
+
 new() ->
     off.
 
 value(Flag) ->
+    Flag.
+
+value(_, Flag) ->
     Flag.
 
 update(enable, _Actor, _Flag) ->
@@ -68,6 +73,12 @@ merge(FA, FB) ->
 
 equal(FA,FB) ->
     FA =:= FB.
+
+from_binary(<<?TAG:7, 0:1>>) -> off;
+from_binary(<<?TAG:7, 1:1>>) -> on.
+
+to_binary(off) -> <<?TAG:7, 0:1>>;
+to_binary(on) -> <<?TAG:7, 1:1>>.
 
 %% priv
 flag_or(on, _) ->

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -52,7 +52,7 @@
 
 -opaque gcounter() :: [entry()].
 
--type entry() :: {Actor::term(), Count::pos_integer()}.
+-type entry() :: {Actor::riak_dt:actor(), Count::pos_integer()}.
 -type gcounter_op() :: increment | {increment, pos_integer()}.
 
 %% @doc Create a new, empty `gcounter()'

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -50,15 +50,14 @@
 
 -export_type([gcounter/0, gcounter_op/0]).
 
--opaque gcounter() :: [entry()].
+-opaque gcounter() :: orddict:orddict().
 
--type entry() :: {Actor::riak_dt:actor(), Count::pos_integer()}.
 -type gcounter_op() :: increment | {increment, pos_integer()}.
 
 %% @doc Create a new, empty `gcounter()'
 -spec new() -> gcounter().
 new() ->
-    [].
+    orddict:new().
 
 %% @doc Create a `gcounter()' with an initial update
 -spec new(term(), pos_integer()) -> gcounter().
@@ -88,41 +87,20 @@ update({increment, Amount}, Actor, GCnt) when is_integer(Amount), Amount > 0 ->
 %% function described in the literature.
 -spec merge(gcounter(), gcounter()) -> gcounter().
 merge(GCnt1, GCnt2) ->
-    merge(GCnt1, GCnt2, []).
-
-%% @private merge two counters.
--spec merge(gcounter(), gcounter(), gcounter()) -> gcounter().
-merge([], [], Acc) ->
-    lists:reverse(Acc);
-merge(LeftOver, [], Acc) ->
-    lists:reverse(Acc, LeftOver);
-merge([], LeftOver, Acc) ->
-    lists:reverse(Acc, LeftOver);
-merge([{Actor1, Cnt1}=AC1|Rest], Clock2, Acc) ->
-    case lists:keytake(Actor1, 1, Clock2) of
-        {value, {Actor1, Cnt2}, RestOfClock2} ->
-            merge(Rest, RestOfClock2, [{Actor1, max(Cnt1, Cnt2)}|Acc]);
-        false ->
-            merge(Rest, Clock2, [AC1|Acc])
-    end.
+    orddict:merge(fun(_, V1, V2) -> max(V1,V2) end,
+                  GCnt1, GCnt2).
 
 %% @doc Are two `gcounter()'s structurally equal? This is not `value/1' equality.
 %% Two counters might represent the total `42', and not be `equal/2'. Equality here is
 %% that both counters contain the same actors and those actors have the same count.
 -spec equal(gcounter(), gcounter()) -> boolean().
 equal(VA,VB) ->
-    lists:sort(VA) =:= lists:sort(VB).
+    lists:sort(orddict:to_list(VA)) =:= lists:sort(orddict:to_list(VB)).
 
 %% @private peform the increment.
 -spec increment_by(pos_integer(), term(), gcounter()) -> gcounter().
 increment_by(Amount, Actor, GCnt) when is_integer(Amount), Amount > 0 ->
-    {Ctr, NewGCnt} = case lists:keytake(Actor, 1, GCnt) of
-                         false ->
-                             {Amount, GCnt};
-                         {value, {_N, C}, ModGCnt} ->
-                             {C + Amount, ModGCnt}
-                     end,
-    [{Actor, Ctr}|NewGCnt].
+    orddict:update_counter(Actor, Amount, GCnt).
 
 -define(TAG, 70).
 -define(V1_VERS, 1).

--- a/src/riak_dt_lwwreg.erl
+++ b/src/riak_dt_lwwreg.erl
@@ -106,7 +106,7 @@ equal({Val, TS}, {Val, TS}) ->
 equal(_, _) ->
     false.
 
--define(TAG, 71).
+-define(TAG, 72).
 -define(V1_VERS, 1).
 
 %% @doc Encode an effecient binary representation of an `lwwreg()'

--- a/src/riak_dt_multi.erl
+++ b/src/riak_dt_multi.erl
@@ -54,7 +54,7 @@
 
 -export_type([multi/0]).
 
--opaque multi() :: {schema(), valuelist()}.
+-type multi() :: {schema(), valuelist()}.
 -type schema() :: riak_dt_vvorset:vvorset().
 -type field() :: {Name::term(), Type::crdt_mod()}.
 -type crdt_mod() :: riak_dt_gcounter | riak_dt_pncounter | riak_dt_lwwreg |

--- a/src/riak_dt_multi.erl
+++ b/src/riak_dt_multi.erl
@@ -52,6 +52,8 @@
          init_state/0, generate/0]).
 -endif.
 
+-export_type([multi/0]).
+
 -opaque multi() :: {schema(), valuelist()}.
 -type schema() :: riak_dt_vvorset:vvorset().
 -type field() :: {Name::term(), Type::crdt_mod()}.

--- a/src/riak_dt_od_flag.erl
+++ b/src/riak_dt_od_flag.erl
@@ -28,7 +28,7 @@
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--export([gen_op/0, update_expected/3, eqc_state_value/1]).
+-export([gen_op/0, init_state/0, update_expected/3, eqc_state_value/1]).
 -endif.
 
 -ifdef(TEST).
@@ -123,7 +123,7 @@ unique_token(Actor) ->
 
 -ifdef(EQC).
 eqc_value_test_() ->
-    {timeout, 1200, [?_assert(crdt_statem_eqc:prop_converge(init_state(), 10000, ?MODULE))]}.
+    crdt_statem_eqc:run(?MODULE, 1000).
 -endif.
 
 new_test() ->

--- a/src/riak_dt_od_flag.erl
+++ b/src/riak_dt_od_flag.erl
@@ -24,7 +24,7 @@
 
 -behaviour(riak_dt).
 
--export([new/0, value/1, update/3, merge/2, equal/2]).
+-export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -77,6 +77,9 @@ value({Enables,Disables}=_Flag) ->
         _ -> on
     end.
 
+value(_, Flag) ->
+    value(Flag).
+
 update(enable, Actor, {Enables,Disables}=_Flag) ->
     Token = unique_token(Actor),
     Enables1 = ordsets:add_element(Token,Enables),
@@ -91,6 +94,22 @@ merge({EA,DA}=_FA, {EB,DB}=_FB) ->
 
 equal(FlagA,FlagB) ->
     FlagA == FlagB.
+
+-define(TAG, 73).
+-define(VSN1, 1).
+
+from_binary(<<?TAG:8, ?VSN1:8, ESize:32, DSize:32,
+              EBin:ESize/binary, DBin:DSize/binary>>) ->
+    Enables = ordsets:from_list([ E || <<E:32>> <= EBin ]),
+    Disables = ordsets:from_list([ D || <<D:32>> <= DBin ]),
+    {Enables, Disables}.
+
+to_binary({Enables, Disables}) ->
+    ESize = ordsets:size(Enables) * 4,
+    DSize = ordsets:size(Disables) * 4,
+    EBin = << <<T:32>> || T <- ordsets:to_list(Enables) >>,
+    DBin = << <<T:32>> || T <- ordsets:to_list(Disables) >>,
+    <<?TAG:8, ?VSN1:8, ESize:32, DSize:32, EBin/binary, DBin/binary>>.
 
 %% priv
 unique_token(Actor) ->
@@ -141,5 +160,12 @@ merge_concurrent_test() ->
     ?assertEqual(on, value(merge(F1,F3))),
     ?assertEqual(off, value(merge(F1,F2))),
     ?assertEqual(on, value(merge(F2,F3))).
+
+binary_roundtrip_test() ->
+    F0 = new(),
+    F1 = update(enable, 1, F0),
+    F2 = update(disable, 1, F1),
+    F3 = update(enable, 2, F2),
+    ?assert(equal(from_binary(to_binary(F3)), F3)).
 
 -endif.

--- a/src/riak_dt_oe_flag.erl
+++ b/src/riak_dt_oe_flag.erl
@@ -24,11 +24,11 @@
 
 -behaviour(riak_dt).
 
--export([new/0, value/1, update/3, merge/2, equal/2]).
+-export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--export([gen_op/0, update_expected/3, eqc_state_value/1]).
+-export([gen_op/0, init_state/0, update_expected/3, eqc_state_value/1]).
 -endif.
 
 -ifdef(TEST).
@@ -77,6 +77,9 @@ value({Disables,Enables}=_Flag) ->
         _ -> off
     end.
 
+value(_, Flag) ->
+    value(Flag).
+
 update(disable, Actor, {Disables,Enables}=_Flag) ->
     Token = unique_token(Actor),
     Disables1 = ordsets:add_element(Token,Disables),
@@ -92,6 +95,22 @@ merge({DA,EA}=_FA, {DB,EB}=_FB) ->
 equal(FlagA,FlagB) ->
     FlagA == FlagB.
 
+-define(TAG, 74).
+-define(VSN1, 1).
+
+from_binary(<<?TAG:8, ?VSN1:8, ESize:32, DSize:32,
+              EBin:ESize/binary, DBin:DSize/binary>>) ->
+    Enables = ordsets:from_list([ E || <<E:32>> <= EBin ]),
+    Disables = ordsets:from_list([ D || <<D:32>> <= DBin ]),
+    {Enables, Disables}.
+
+to_binary({Enables, Disables}) ->
+    ESize = ordsets:size(Enables) * 4,
+    DSize = ordsets:size(Disables) * 4,
+    EBin = << <<T:32>> || T <- ordsets:to_list(Enables) >>,
+    DBin = << <<T:32>> || T <- ordsets:to_list(Disables) >>,
+    <<?TAG:8, ?VSN1:8, ESize:32, DSize:32, EBin/binary, DBin/binary>>.
+
 %% priv
 unique_token(Actor) ->
     erlang:phash2({Actor, erlang:now()}).
@@ -104,7 +123,7 @@ unique_token(Actor) ->
 
 -ifdef(EQC).
 eqc_value_test_() ->
-    {timeout, 1200, [?_assert(crdt_statem_eqc:prop_converge(init_state(), 10000, ?MODULE))]}.
+    crdt_statem_eqc:run(?MODULE, 1000).
 -endif.
 
 new_test() ->

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -24,6 +24,9 @@
 
 -behaviour(riak_dt).
 
+-export_type([orset/0]).
+-opaque orset() :: {orddict:orddict(), orddict:orddict()}.
+
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -endif.

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -140,7 +140,7 @@ equal(PNCntA, PNCntB) ->
 -define(V2_VERS, 2).
 
 %% @doc Encode an effecient binary representation of `pncounter()'
--spec to_binary(pncounter()) -> binary().
+-spec to_binary(any_pncounter()) -> binary().
 to_binary(PNCnt) ->
     to_binary(?V2_VERS, PNCnt).
 

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -50,7 +50,7 @@
 
 -export_type([pncounter/0, pncounter_op/0]).
 
--opaque pncounter()  :: [{Actor::term(), Inc::pos_integer(), Dec::pos_integer()}].
+-opaque pncounter()  :: [{Actor::riak_dt:actor(), Inc::pos_integer(), Dec::pos_integer()}].
 -type pncounter_op() :: riak_dt_gcounter:gcounter_op() | decrement_op().
 -type decrement_op() :: decrement | {decrement, pos_integer()}.
 -type pncounter_q()  :: positive | negative.
@@ -80,7 +80,7 @@ value(PNCnt) ->
 
 %% @doc query the parts of a `pncounter()'
 %% valid queries are `positive' or `negative'.
--spec value(pncounter_q(), pncounter()) -> pncounter().
+-spec value(pncounter_q(), pncounter()) -> integer().
 value(positive, PNCnt) ->
     lists:sum([Inc || {_Act,Inc,_Dec} <- PNCnt]);
 value(negative, PNCnt) ->
@@ -103,7 +103,7 @@ update({_IncrDecr, 0}, _Actor, PNCnt) ->
 update({increment, By}, Actor, PNCnt) when is_integer(By), By > 0 ->
     increment_by(By, Actor, PNCnt);
 update({increment, By}, Actor, PNCnt) when is_integer(By), By < 0 ->
-    update({decrement, By}, Actor, PNCnt);
+    update({decrement, -By}, Actor, PNCnt);
 update({decrement, By}, Actor, PNCnt) when is_integer(By), By > 0 ->
     decrement_by(By, Actor, PNCnt).
 
@@ -246,10 +246,12 @@ init_state() ->
     0.
 
 gen_op() ->
-    oneof([increment, {increment, gen_pos()}, decrement, {decrement, gen_pos()} ]).
-
-gen_pos()->
-    ?LET(X, int(), 1+abs(X)).
+    oneof([increment,
+           {increment, nat()},
+           decrement,
+           {decrement, nat()},
+           {increment, ?LET(X, nat(), -X)}
+          ]).
 
 update_expected(_ID, increment, Prev) ->
     Prev+1;

--- a/src/riak_dt_vclock.erl
+++ b/src/riak_dt_vclock.erl
@@ -130,6 +130,7 @@ equal(VA,VB) ->
 %% 2 tuple list, assumes the first element in the
 %% actor map is present in the clock, and the second will
 %% replace it.
+-spec replace_actors([{vclock_node(), vclock_node()}], vclock()) -> vclock().
 replace_actors(ActorMap, Vclock) ->
     replace_actors(ActorMap, Vclock, 1).
 
@@ -137,6 +138,7 @@ replace_actors(ActorMap, Vclock) ->
 %% in the provided actor map list.
 %% The element at `KeyPos` is the actor in the vclock
 %% the other element in the actor map 2 tuple replaces it.
+-spec replace_actors([{vclock_node(), vclock_node()}], vclock(), 1 | 2) -> vclock().
 replace_actors(ActorMap, Vclock, KeyPos) ->
     lists:foldl(fun({CurrActor, Cntr}, NewClock) ->
                         Map = lists:keyfind(CurrActor, KeyPos, ActorMap),

--- a/src/riak_dt_vvorset.erl
+++ b/src/riak_dt_vvorset.erl
@@ -87,14 +87,12 @@
 %% a dict of actor() -> Alias::integer() mappings
 %% Reason being to keep the vector clocks as small as
 %% possible and not repeat actor names over and over.
--type actorlist() :: orddict:orddict().
-
--type actor() :: term().
-
+-type actorlist() :: [ {actor(), integer()} ].
+-type actor() :: riak_dt:actor().
 %% a dict of member() -> member_info() mappings.
 %% The vclock is simply a more effecient way of storing
 %% knowledge about adds / removes than a UUID per add.
--type entries() :: orddict:orddict().
+-type entries() :: [{member(), member_info()}].
 
 -type member_info() :: {boolean(), riak_dt_vclock:vclock()}.
 -type member() :: term().
@@ -121,7 +119,8 @@ value(tombstones, {_Actors, Entries}) ->
 -spec update(vvorset_op(), actor(), vvorset()) -> vvorset().
 update({add, Elem}, Actor, ORSet) ->
     add_elem(Actor, ORSet, Elem);
-update({remove, Elem}, _Actor, {_Actors, Entries}=ORSet) ->
+update({remove, Elem}, _Actor, ORSet) ->
+    {_Actors, Entries} = ORSet,
     remove_elem(orddict:find(Elem, Entries), Elem, ORSet).
 
 -spec merge(vvorset(), vvorset()) -> vvorset().
@@ -199,7 +198,6 @@ actor_placeholder(Actor, Actors) ->
             {Placeholder, orddict:store(Actor, Placeholder, Actors)}
     end.
 
--spec remove_elem({ok, member_info()} | error, member(), vvorset()) -> vvorset().
 remove_elem({ok, {1, Vclock}}, Elem, {AL, Dict}) ->
     {AL, orddict:store(Elem, {0, Vclock}, Dict)};
 remove_elem({ok, {0, _Vclock}}, _Elem, ORSet) ->

--- a/src/riak_dt_vvorset.erl
+++ b/src/riak_dt_vvorset.erl
@@ -159,8 +159,6 @@ vclock_merge(V10, V20, Actors1, Actors2, MergedActors) ->
 
 %% @Doc determine if the entry is active or removed.
 %% First argument is a remove vclock, second is an active vclock
--spec is_active_or_removed(riak_dt_vclock:vclock(), riak_dt_vclock:vclock(),
-                           actorlist(), actorlist(), actorlist()) -> member_info().
 is_active_or_removed(RemoveClock0, AddClock0, RemActors, AddActors, MergedActors) ->
     RemoveClock = riak_dt_vclock:replace_actors(orddict:to_list(RemActors), RemoveClock0, 2),
     AddClock = riak_dt_vclock:replace_actors(orddict:to_list(AddActors), AddClock0, 2),

--- a/src/riak_dt_zorset.erl
+++ b/src/riak_dt_zorset.erl
@@ -49,8 +49,8 @@
 
 -export_type([zorset/0, zorset_op/0]).
 
--opaque zorset() :: riak_dt_multi:multi().
--opaque zorset_op() :: {add, member(), score()} | {remove, member()} | {incr, member(), score()}.
+-type zorset() :: riak_dt_multi:multi().
+-type zorset_op() :: {add, member(), score()} | {remove, member()} | {incr, member(), score()}.
 
 -type zorset_q()  :: size | {contains, term()}.
 


### PR DESCRIPTION
Start of some work to remove warnings and other bugs in our data-types. 

Still TODO:
- [x] orset_bm.erl:24: Expression produces a value of type ['true'], but this value is unmatched
- [x] orset_bm.erl:103: Expression produces a value of type 'ok' | {'merge',pid(),_}, but this value is unmatched
- [x] riak_dt_vvorset.erl:125: The call riak_dt_vvorset:remove_elem('error' | {'ok',_},Elem::any(),ORSet::{_,_}) does not have an opaque term of type riak_dt_vvorset:vvorset() as 3rd argument
- [x] riak_dt_vvorset.erl:158: The call riak_dt_vclock:merge([maybe_improper_list(),...]) does not have a term of type [ riak_dt_vclock:vclock() ] (with opaque subterms) as 1st argument
- [x] riak_dt_vvorset.erl:163: Invalid type specification for function riak_dt_vvorset:is_active_or_removed/5. The success typing is ([any()],[any()],[{_,_}],[{_,_}],[{_,_}]) -> {0 | 1,maybe_improper_list()}
- [x] riak_dt_zorset.erl:62: Invalid type specification for function riak_dt_zorset:new/0. The success typing is () -> riak_dt_multi:multi()
- [x] riak_dt_zorset.erl:66: Invalid type specification for function riak_dt_zorset:value/1. The success typing is ({riak_dt_vvorset:vvorset(),_}) -> [{_,_}]
- [x] riak_dt_zorset.erl:72: Invalid type specification for function riak_dt_zorset:value/2. The success typing is ('size' | {'contains',_},{riak_dt_vvorset:vvorset(),_}) -> boolean() | non_neg_integer()
- [x] riak_dt_zorset.erl:83: The call riak_dt_multi:update({'update',[riak_dt_zorset:zorset_op(),...]},Actor::any(),ZORSet::any()) contains an opaque term as 1st argument when terms of different types are expected in these positions
- [x] riak_dt_zorset.erl:95: Invalid type specification for function riak_dt_zorset:merge/2. The success typing is (riak_dt_multi:multi(),riak_dt_multi:multi()) -> riak_dt_multi:multi()
- [x] riak_dt_zorset.erl:99: Invalid type specification for function riak_dt_zorset:equal/2. The success typing is (riak_dt_multi:multi(),riak_dt_multi:multi()) -> boolean()
