### PR TITLE
Improve efficiency of flags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dev/*
 doc/*
 rel/riak_dt
 data/*
+.qc/*
+.eqc-info
+current_counterexample.eqc

--- a/src/riak_dt_od_flag.erl
+++ b/src/riak_dt_od_flag.erl
@@ -42,7 +42,6 @@
 -opaque od_flag() :: {riak_dt_vclock:vclock(), on | off}.
 -type od_flag_op() :: enable | disable.
 
-% {Enables,Disables}
 -spec new() -> od_flag().
 new() ->
     {riak_dt_vclock:fresh(), off}.


### PR DESCRIPTION
This changes the OE/OD flags to be "tombstone-less", like ORSWOTs (or more accurately, VVORSets). Basically the "observed" operation flips the flag without incrementing, while the opposite operation increments the vector clock. This greatly reduces space complexity, and consolidates our garbage into the same type as produced by other types, namely actor IDs.

I also put the binary-roundtrip EQC into both of these types and added type annotations.

@russelldb 
