### PR TITLE
Added assign w/o timestamp top the lwwreg_op.

### DIFF
--- a/src/riak_dt_lwwreg.erl
+++ b/src/riak_dt_lwwreg.erl
@@ -47,7 +47,7 @@
 
 -opaque lwwreg() :: {term(), non_neg_integer()}.
 
--type lwwreg_op() :: {assign, term(), non_neg_integer()}.
+-type lwwreg_op() :: {assign, term(), non_neg_integer()}  | {assign, term()}.
 
 -type lww_q() :: timestamp.
 


### PR DESCRIPTION
{assign, Value} is a valid lwwreg_op at this time, it should be declared as such to make dialyzer happy.
