### PR TITLE
Add a stats/1 callback to all datatypes.

### DIFF
--- a/src/riak_dt.erl
+++ b/src/riak_dt.erl
@@ -38,6 +38,7 @@
 -callback equal(crdt(), crdt()) -> boolean().
 -callback to_binary(crdt()) -> binary().
 -callback from_binary(binary()) -> crdt().
+-callback stats(crdt()) -> [{atom(), number()}].
 
 -ifdef(EQC).
 % Extra callbacks for any crdt_statem_eqc tests

--- a/src/riak_dt_disable_flag.erl
+++ b/src/riak_dt_disable_flag.erl
@@ -29,7 +29,7 @@
 
 -behaviour(riak_dt).
 
--export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1]).
+-export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1, stats/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -38,23 +38,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--endif.
-
-%% EQC generator
--ifdef(EQC).
-init_state() ->
-    on.
-
-gen_op() ->
-    disable.
-
-update_expected(_ID, disable, _Prev) ->
-    off;
-update_expected(_ID, _Op, Prev) ->
-    Prev.
-
-eqc_state_value(S) ->
-    S.
 -endif.
 
 -define(TAG, 80).
@@ -82,6 +65,8 @@ from_binary(<<?TAG:7, 1:1>>) -> on.
 
 to_binary(off) -> <<?TAG:7, 0:1>>;
 to_binary(on) -> <<?TAG:7, 1:1>>.
+
+stats(_) -> [].
 
 %% priv
 flag_and(on, on) ->
@@ -135,4 +120,22 @@ merge_on_both_test() ->
     {ok, F1} = update(disable, 1, F0),
     ?assertEqual(off, merge(F1, F1)).
 
+-endif.
+
+
+%% EQC generator
+-ifdef(EQC).
+init_state() ->
+    on.
+
+gen_op() ->
+    disable.
+
+update_expected(_ID, disable, _Prev) ->
+    off;
+update_expected(_ID, _Op, Prev) ->
+    Prev.
+
+eqc_state_value(S) ->
+    S.
 -endif.

--- a/src/riak_dt_disable_flag.erl
+++ b/src/riak_dt_disable_flag.erl
@@ -42,30 +42,43 @@
 
 -define(TAG, 80).
 
+-export_type([disable_flag/0]).
+-opaque disable_flag() :: on | off.
+-type disable_flag_op() :: disable.
+
+-spec new() -> disable_flag().
 new() ->
     on.
 
+-spec value(disable_flag()) -> on | off.
 value(Flag) ->
     Flag.
 
+-spec value(term(), disable_flag()) -> on | off.
 value(_, Flag) ->
     Flag.
 
+-spec update(disable_flag_op(), riak_dt:actor(), disable_flag()) -> {ok, disable_flag()}.
 update(disable, _Actor, _Flag) ->
     {ok, off}.
 
+-spec merge(disable_flag(), disable_flag()) -> disable_flag().
 merge(FA, FB) ->
     flag_and(FA, FB).
 
+-spec equal(disable_flag(), disable_flag()) -> boolean().
 equal(FA,FB) ->
     FA =:= FB.
 
+-spec from_binary(binary()) -> disable_flag().
 from_binary(<<?TAG:7, 0:1>>) -> off;
 from_binary(<<?TAG:7, 1:1>>) -> on.
 
+-spec to_binary(disable_flag()) -> binary().
 to_binary(off) -> <<?TAG:7, 0:1>>;
 to_binary(on) -> <<?TAG:7, 1:1>>.
 
+-spec stats(disable_flag()) -> [{atom(), number()}].
 stats(_) -> [].
 
 %% priv

--- a/src/riak_dt_enable_flag.erl
+++ b/src/riak_dt_enable_flag.erl
@@ -42,30 +42,43 @@
 
 -define(TAG, 79).
 
+-export_type([enable_flag/0]).
+-opaque enable_flag() :: on | off.
+-type enable_flag_op() :: enable.
+
+-spec new() -> enable_flag().
 new() ->
     off.
 
+-spec value(enable_flag()) -> on | off.
 value(Flag) ->
     Flag.
 
+-spec value(term(), enable_flag()) -> on | off.
 value(_, Flag) ->
     Flag.
 
+-spec update(enable_flag_op(), riak_dt:actor(), enable_flag()) -> {ok, enable_flag()}.
 update(enable, _Actor, _Flag) ->
     {ok, on}.
 
+-spec merge(enable_flag(), enable_flag()) -> enable_flag().
 merge(FA, FB) ->
     flag_or(FA, FB).
 
+-spec equal(enable_flag(), enable_flag()) -> boolean().
 equal(FA,FB) ->
     FA =:= FB.
 
+-spec from_binary(binary()) -> enable_flag().
 from_binary(<<?TAG:7, 0:1>>) -> off;
 from_binary(<<?TAG:7, 1:1>>) -> on.
 
+-spec to_binary(enable_flag()) -> binary().
 to_binary(off) -> <<?TAG:7, 0:1>>;
 to_binary(on) -> <<?TAG:7, 1:1>>.
 
+-spec stats(enable_flag()) -> [{atom(), number()}].
 stats(_) -> [].
 
 %% priv

--- a/src/riak_dt_enable_flag.erl
+++ b/src/riak_dt_enable_flag.erl
@@ -29,7 +29,7 @@
 
 -behaviour(riak_dt).
 
--export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1]).
+-export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1, stats/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -65,6 +65,8 @@ from_binary(<<?TAG:7, 1:1>>) -> on.
 
 to_binary(off) -> <<?TAG:7, 0:1>>;
 to_binary(on) -> <<?TAG:7, 1:1>>.
+
+stats(_) -> [].
 
 %% priv
 flag_or(on, _) ->

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -35,8 +35,8 @@
 %% @end
 
 -module(riak_dt_gcounter).
-
--export([new/0, new/2, value/1, value/2, update/3, merge/2, equal/2, to_binary/1, from_binary/1]).
+-behaviour(riak_dt).
+-export([new/0, new/2, value/1, value/2, update/3, merge/2, equal/2, to_binary/1, from_binary/1, stats/1]).
 
 %% EQC API
 -ifdef(EQC).
@@ -102,6 +102,10 @@ equal(VA,VB) ->
 -spec increment_by(pos_integer(), term(), gcounter()) -> gcounter().
 increment_by(Amount, Actor, GCnt) when is_integer(Amount), Amount > 0 ->
     orddict:update_counter(Actor, Amount, GCnt).
+
+-spec stats(gcounter()) -> [{atom(), number()}].
+stats(GCnt) ->
+    [{actor_counter, length(GCnt)}].
 
 -define(TAG, 70).
 -define(V1_VERS, 1).

--- a/src/riak_dt_gset.erl
+++ b/src/riak_dt_gset.erl
@@ -34,7 +34,7 @@
 
 %% API
 -export([new/0, value/1, update/3, merge/2, equal/2,
-         to_binary/1, from_binary/1, value/2]).
+         to_binary/1, from_binary/1, value/2, stats/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -101,6 +101,15 @@ to_binary(GSet) ->
 from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
     %% @TODO something smarter
     binary_to_term(Bin).
+
+stats(GSet) ->
+    [{element_count, length(GSet)},
+     {max_element_size,
+      ordsets:fold(
+        fun(E, S) ->
+                max(erlang:external_size(E), S)
+        end, 0, GSet)}
+    ].
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_gset.erl
+++ b/src/riak_dt_gset.erl
@@ -98,10 +98,12 @@ to_binary(GSet) ->
     %% @TODO something smarter
     <<?TAG:8/integer, ?V1_VERS:8/integer, (term_to_binary(GSet))/binary>>.
 
+-spec from_binary(binary()) -> gset().
 from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
     %% @TODO something smarter
     binary_to_term(Bin).
 
+-spec stats(gset()) -> [{atom(), number()}].
 stats(GSet) ->
     [{element_count, length(GSet)},
      {max_element_size,

--- a/src/riak_dt_lwwreg.erl
+++ b/src/riak_dt_lwwreg.erl
@@ -29,9 +29,10 @@
 %% @end
 
 -module(riak_dt_lwwreg).
+-behaviour(riak_dt).
 
 -export([new/0, value/1, value/2, update/3, merge/2,
-         equal/2, to_binary/1, from_binary/1]).
+         equal/2, to_binary/1, from_binary/1, stats/1]).
 
 %% EQC API
 -ifdef(EQC).
@@ -111,6 +112,10 @@ equal({Val, TS}, {Val, TS}) ->
     true;
 equal(_, _) ->
     false.
+
+-spec stats(lwwreg()) -> [{atom(), number()}].
+stats({Value, _}) -> 
+    [{value_size, erlang:external_size(Value)}].
 
 -define(TAG, 72).
 -define(V1_VERS, 1).

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -44,7 +44,7 @@
 
 %% API
 -export([new/0, value/1, value/2, update/3, merge/2,
-         equal/2, to_binary/1, from_binary/1, precondition_context/1]).
+         equal/2, to_binary/1, from_binary/1, precondition_context/1, stats/1]).
 
 %% EQC API
 -ifdef(EQC).
@@ -292,6 +292,18 @@ short_circuit_equals([{{_Name, Mod}=Field, {Dot1,Val1}} | Rest], Values2) ->
 -spec precondition_context(map()) -> map().
 precondition_context(Map) ->
     Map.
+
+-spec stats(map()) -> [{atom(), integer()}].
+stats({Clock, Fields}) ->
+    [
+     {actor_count, length(Clock)},
+     {field_count, orddict:size(Fields)},
+     {max_dot_length,
+      orddict:fold(fun(_K, {Dots, _}, Acc) ->
+                           max(length(Dots), Acc)
+                   end, 0, Fields)}
+    ].
+
 
 -define(TAG, 77).
 -define(V1_VERS, 1).

--- a/src/riak_dt_od_flag.erl
+++ b/src/riak_dt_od_flag.erl
@@ -25,7 +25,7 @@
 
 -behaviour(riak_dt).
 
--export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1]).
+-export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1, stats/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -89,6 +89,10 @@ merge({C1, _}=ODF1, {C2, _}=ODF2) ->
 equal({C1,F},{C2,F}) ->
     riak_dt_vclock:equal(C1,C2);
 equal(_,_) -> false.
+
+-spec stats(od_flag()) -> [{atom(), integer()}].
+stats({C, _}) ->
+    [{actor_count, length(C)}].
 
 -define(TAG, 73).
 -define(VSN1, 1).

--- a/src/riak_dt_oe_flag.erl
+++ b/src/riak_dt_oe_flag.erl
@@ -25,7 +25,7 @@
 
 -behaviour(riak_dt).
 
--export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1]).
+-export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1, stats/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -110,6 +110,9 @@ to_binary({Clock, Flag}) ->
     VCBin = riak_dt_vclock:to_binary(Clock),
     <<?TAG:8, ?VSN1:8, BFlag:8, VCBin/binary>>.
 
+-spec stats(oe_flag()) -> [{atom(), integer()}].
+stats({C, _}) ->
+    [{actor_count, length(C)}].
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -26,7 +26,7 @@
 
 %% API
 -export([new/0, value/1, update/3, merge/2, equal/2,
-         to_binary/1, from_binary/1, value/2, precondition_context/1]).
+         to_binary/1, from_binary/1, value/2, precondition_context/1, stats/1]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -114,6 +114,18 @@ precondition_context(ORDict) ->
                 Tokens1 -> orddict:store(Elem, Tokens1, ORDict1)
             end
         end, orddict:new(), ORDict).
+
+-spec stats(orset()) -> [{atom(), number()}].
+stats(ORSet) ->
+    {Tags, Tombs} = orddict:fold(fun(_K, {A, R}, {As, Rs}) ->
+                                         {length(A) + As, length(R) + Rs}
+                                 end, {0,0}, ORSet),
+    [
+     {element_count, orddict:size(ORSet)},
+     {adds_count, Tags},
+     {removes_count, Tombs},
+     {waste_pct, Tombs / Tags * 100}
+    ].
 
 -define(TAG, 76).
 -define(V1_VERS, 1).

--- a/src/riak_dt_orswot.erl
+++ b/src/riak_dt_orswot.erl
@@ -78,7 +78,7 @@
 -export([new/0, value/1, value/2]).
 -export([update/3, merge/2, equal/2]).
 -export([to_binary/1, from_binary/1]).
--export([precondition_context/1]).
+-export([precondition_context/1, stats/1]).
 
 %% EQC API
 -ifdef(EQC).
@@ -269,6 +269,17 @@ remove_elem(_, Elem, _ORSet) ->
 -spec precondition_context(orswot()) -> orswot().
 precondition_context(ORSet) ->
     ORSet.
+
+-spec stats(orswot()) -> [{atom(), number()}].
+stats({Clock, Dict}) ->
+    [
+     {actor_count, length(Clock)},
+     {element_count, orddict:size(Dict)},
+     {max_dot_length,
+      orddict:fold(fun(_K, Dots, Acc) ->
+                           max(length(Dots), Acc)
+                   end, 0, Dict)}
+     ].
 
 -define(TAG, 75).
 -define(V1_VERS, 1).

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -33,9 +33,10 @@
 %% @end
 
 -module(riak_dt_pncounter).
+-behaviour(riak_dt).
 
 -export([new/0, new/2, value/1, value/2,
-         update/3, merge/2, equal/2, to_binary/1, from_binary/1]).
+         update/3, merge/2, equal/2, to_binary/1, from_binary/1, stats/1]).
 -export([to_binary/2, from_binary/2, current_version/1, change_versions/3]).
 
 %% EQC API
@@ -134,6 +135,10 @@ merge([{Act,IncA,DecA}=ACntA|RestA],PNCntB, Acc) ->
 -spec equal(pncounter(), pncounter()) -> boolean().
 equal(PNCntA, PNCntB) ->
     lists:sort(PNCntA) =:= lists:sort(PNCntB).
+
+-spec stats(pncounter()) -> [{atom(), number()}].
+stats(PNCounter) ->
+    [{actor_count, length(PNCounter)}].
 
 -define(TAG, 71).
 -define(V1_VERS, 1).


### PR DESCRIPTION
The callback returns a proplist of atom/number pairs about internal statistics of the datatype. Examples include 'actor_count' (on any VV-based type), 'element_count' (sets), 'field_count' (maps), 'max_dot_length' (on dotted VV-based types).

Still undecided: whether to recurse into embedded values for internal stats.
