### PR TITLE
Our to/from binary was slow slow slow, use t2b (with compression)

### DIFF
--- a/src/riak_dt.app.src
+++ b/src/riak_dt.app.src
@@ -11,7 +11,7 @@
   %% @See docs for erlang:term_to_binary/2. Compression can be either
   %% true | false | integer() when integer() is in a range of 0 - 9. 0
   %% is the same as false, 6 is the same as true.  The integer
-  %% indeicates the level of compression. Higher number means more
+  %% indicates the level of compression. Higher number means more
   %% compression, but more time to compress. In tests so far 1 has
   %% been enough for CRDTs
   {env, [{binary_compression, 1}]}

--- a/src/riak_dt.app.src
+++ b/src/riak_dt.app.src
@@ -8,5 +8,11 @@
                   kernel,
                   stdlib
                  ]},
+  %% @See docs for erlang:term_to_binary/2. Compression can be either
+  %% true | false | integer() when integer() is in a range of 0 - 9. 0
+  %% is the same as false, 6 is the same as true.  The integer
+  %% indeicates the level of compression. Higher number means more
+  %% compression, but more time to compress. In tests so far 1 has
+  %% been enough for CRDTs
   {env, [{binary_compression, 1}]}
  ]}.

--- a/src/riak_dt.app.src
+++ b/src/riak_dt.app.src
@@ -8,5 +8,5 @@
                   kernel,
                   stdlib
                  ]},
-  {env, []}
+  {env, [{binary_compression, 1}]}
  ]}.

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -90,13 +90,6 @@
 -type value() :: {field(), riak_dt_map:values() | integer() | [term()] | boolean() | term()}.
 -type precondition_error() :: {error, {precondition, {not_present, field()}}}.
 
-%% Used by to/from binary to only store mod names once
--type mod_map() :: [{crdt_mod(), pos_integer()}].
-
-%% Used by to/from binary to only store each actor id once
--type actor_map() :: [{riak_dt:actor(), pos_integer()}
-                      | {pos_integer(), riak_dt:actor()}].
-
 %% @doc Create a new, empty Map.
 -spec new() -> map().
 new() ->
@@ -311,180 +304,31 @@ stat(_,_) -> undefined.
 -define(TAG, 77).
 -define(V1_VERS, 1).
 
-%% @doc returns a binary representation of the provided
-%% `map()'. Measurements show that for all but the empty map this
-%% function is more effecient than using
-%% `erlang:term_to_binary/1'. The resulting binary is tagged and
-%% versioned for ease of future upgrade. Calling `from_binary/1' with
-%% the result of this function will return the original map.
+%% @doc returns a binary representation of the provided `map()'. The
+%% resulting binary is tagged and versioned for ease of future
+%% upgrade. Calling `from_binary/1' with the result of this function
+%% will return the original map.  Use the application env var
+%% `binary_compression' to turn t2b compression on (`true') and off
+%% (`false')
 %%
 %% @see `from_binary/1'
 -spec to_binary(map()) -> binary_map().
 to_binary(Map) ->
-    {ModMap, <<?TAG:8/integer, ?V1_VERS:8/integer, MapBin/binary>>} =  to_binary(Map, orddict:new()),
-    ModMapBin = mod_map_to_binary(ModMap),
-    ModMapBinLen = byte_size(ModMapBin),
-    <<?TAG:8/integer, ?V1_VERS:8/integer,
-      ModMapBinLen:32/integer,
-      ModMapBin:ModMapBinLen/binary,
-      MapBin/binary>>.
+    Opts = case application:get_env(riak_dt, binary_compression, true) of
+               true -> [compressed];
+               N when N >= 0, N =< 9 -> [{compressed, N}];
+               _ -> []
+           end,
+    <<?TAG:8/integer, ?V1_VERS:8/integer, (term_to_binary(Map, Opts))/binary>>.
 
 %% @doc When the argument is a `binary_map()' produced by
 %% `to_binary/1' will return the original `map()'.
 %%
 %% @see `to_binary/1'
 -spec from_binary(binary_map()) -> map().
-from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer,
-              ModMapBinLen:32/integer, ModMapBin:ModMapBinLen/binary,
-              MapBin/binary>>) ->
-    ModMap = mod_map_from_binary(ModMapBin),
-    from_binary(MapBin, ModMap).
+from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, B/binary>>) ->
+    binary_to_term(B).
 
-%% @private internal `to_binary/2' for submaps. Threads the `ModMap'
-%% through all submaps so that we don't duplicate information.
--spec to_binary(map(), mod_map()) -> {mod_map(), binary_map()}.
-to_binary({Clock, Fields}, ModMap0) ->
-    Actors0 = riak_dt_vclock:all_nodes(Clock),
-    Actors = lists:zip(Actors0, lists:seq(1, length(Actors0))),
-    BinClock = riak_dt_vclock:to_binary(Clock),
-    ClockLen = byte_size(BinClock),
-    %% since each minimal clock can be at _most_ the size of the
-    %% vclock for the set, this saves us reserving 4 bytes for clock
-    %% len for each entry if we only needs 1 (for example)
-    ClockLenFieldLen = bit_size(binary:encode_unsigned(ClockLen)),
-    {ModMap, BinFields} = fields_to_binary(Fields, ClockLenFieldLen, Actors, ModMap0, <<>>),
-    {ModMap, <<?TAG:8/integer, ?V1_VERS:8/integer,
-      ClockLenFieldLen:8/integer,
-      ClockLen:ClockLenFieldLen/integer,
-      BinClock:ClockLen/binary,
-      BinFields/binary>>}.
-
-%% @private internal from binary that threads the `ModMap' for use by
-%% all submaps.
--spec from_binary(binary(), mod_map()) -> map().
-from_binary(<<ClockLenFieldLen:8/integer, ClockLen:ClockLenFieldLen/integer,
-              BinClock:ClockLen/binary, BinFields/binary>>, ModMap) ->
-    Clock = riak_dt_vclock:from_binary(BinClock),
-    Actors0 = riak_dt_vclock:all_nodes(Clock),
-    Actors = lists:zip(lists:seq(1, length(Actors0)), Actors0),
-    Fields = binary_to_fields(BinFields, ClockLenFieldLen, Actors, ModMap, orddict:new()),
-    {Clock, Fields}.
-
-%% @private inverse of 'binary_to_fields/5'
--spec fields_to_binary(valuelist(), pos_integer(), actor_map(),
-                       mod_map(), binary()) ->
-                              {mod_map(), binary()}.
-fields_to_binary([], _, _, ModMap, BinFields) ->
-    {ModMap, BinFields};
-fields_to_binary([{Field, {Clock0, CRDT}} | Rest], ClockLenFieldLen, Actors, ModMap0, Acc) ->
-    {ModMap, CRDTBin} = crdt_to_binary(Field, CRDT, ModMap0),
-    CRDTBinLen = byte_size(CRDTBin),
-    Clock = riak_dt_vclock:replace_actors(Actors, Clock0),
-    ClockBin = riak_dt_vclock:to_binary(Clock),
-    ClockLen = byte_size(ClockBin),
-    Bin = <<CRDTBinLen:32/integer, CRDTBin:CRDTBinLen/binary,
-            ClockLen:ClockLenFieldLen/integer, ClockBin:ClockLen/binary>>,
-    fields_to_binary(Rest, ClockLenFieldLen, Actors, ModMap, <<Acc/binary, Bin/binary>>).
-
-%% @private inverse of 'binary_to_crdt/2'
--spec crdt_to_binary(field(), crdt(), mod_map()) -> {mod_map(), binary()}.
-crdt_to_binary({Name, Mod}, CRDT, ModMap0) ->
-    NameBin = name_to_bin(Name),
-    NameBinLen = byte_size(NameBin),
-    {ModMapping, ModMap} = mod_mapping(Mod, ModMap0),
-    {ModMap2, ValueBin} = value_to_binary(Mod, CRDT, ModMap),
-    ValueBinLen = byte_size(ValueBin),
-    Bin = <<ModMapping:8/integer,
-            NameBinLen:32/integer,
-            NameBin:NameBinLen/binary,
-            ValueBinLen:32/integer,
-            ValueBin:ValueBinLen/binary>>,
-    {ModMap2, Bin}.
-
-%% @private inverse of `mod_map_from_binary/1'
--spec mod_map_to_binary(mod_map()) -> binary().
-mod_map_to_binary(ModMap) ->
-    term_to_binary(ModMap).
-
-%% @private inverse of `binary_to_name/1'
--spec name_to_bin(term()) -> binary().
-name_to_bin(Name) when is_binary(Name) ->
-    <<1, Name/binary>>;
-name_to_bin(Name) ->
-    <<0, (term_to_binary(Name))/binary>>.
-
-%% @private inverse of `binary_to_value/3'
--spec value_to_binary(crdt_mod(), crdt(), mod_map()) ->
-                             {mod_map(), binary()}.
-value_to_binary(?MODULE, Value, ModMap) ->
-    to_binary(Value, ModMap);
-value_to_binary(Mod, Value, ModMap) ->
-    {ModMap, Mod:to_binary(Value)}.
-
-%% @private get or generate an int -> mod mapping
--spec mod_mapping(crdt_mod(), mod_map()) -> {pos_integer(), mod_map()}.
-mod_mapping(Mod, ModMap0) ->
-    case orddict:find(Mod, ModMap0) of
-        error ->
-            NewMapping = orddict:size(ModMap0) + 1,
-            {NewMapping, orddict:store(Mod, NewMapping, ModMap0)};
-        {ok, Mapping} ->
-            {Mapping, ModMap0}
-    end.
-
-%% @private inverse of `fields_to_binary/5'
--spec binary_to_fields(binary(), pos_integer(),
-                       actor_map(), mod_map(), valuelist()) ->
-                              valuelist().
-binary_to_fields(<<>>, _, _, _, Fields) ->
-    Fields;
-binary_to_fields(<<CRDTBinLen:32/integer, CRDTBin:CRDTBinLen/binary, Rest0/binary>>,
-                 ClockLenFieldLen, Actors, ModMap, Acc) ->
-    <<ClockLen:ClockLenFieldLen/integer, ClockBin:ClockLen/binary, Rest/binary>> = Rest0,
-    {Field, CRDT} = binary_to_crdt(CRDTBin, ModMap),
-    Clock0 = riak_dt_vclock:from_binary(ClockBin),
-    Clock = riak_dt_vclock:replace_actors(Actors, Clock0),
-    Fields = orddict:store(Field, {Clock, CRDT}, Acc),
-    binary_to_fields(Rest, ClockLenFieldLen, Actors, ModMap, Fields).
-
-%% @private invers of `crdt_to_binary/3'
--spec binary_to_crdt(binary(), mod_map()) ->
-                            {field(), crdt()}.
-binary_to_crdt(<<ModMapping:8/integer,
-            NameBinLen:32/integer,
-            NameBin:NameBinLen/binary,
-            ValueBinLen:32/integer,
-            ValueBin:ValueBinLen/binary>>, ModMap) ->
-    Mod = mod_from_mapping(ModMapping, ModMap),
-    Name = binary_to_name(NameBin),
-    Value = binary_to_value(ValueBin, Mod, ModMap),
-    {{Name, Mod}, Value}.
-
-%% @private inverse of `mod_mapping/2', get the mod for and int
-%% mapping.
--spec mod_from_mapping(pos_integer(), mod_map()) -> crdt_mod().
-mod_from_mapping(ModMapping, ModMap) ->
-    {Mod, ModMapping} = lists:keyfind(ModMapping, 2, ModMap),
-    Mod.
-
-%% @private inverse of `name_to_bin/1'
--spec binary_to_name(binary()) -> term().
-binary_to_name(<<1, Bin/binary>>) ->
-    Bin;
-binary_to_name(<<0, Bin/binary>>) ->
-    binary_to_term(Bin).
-
-%% @private inverse of `binary_to_value/4'
--spec binary_to_value(binary(), crdt_mod(), mod_map()) -> crdt().
-binary_to_value(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>, ?MODULE, ModMap) ->
-    from_binary(Bin, ModMap);
-binary_to_value(Bin, Mod, _) ->
-    Mod:from_binary(Bin).
-
-%% @private inverse of `mod_map_to_binary/1'
--spec mod_map_from_binary(binary()) -> mod_map().
-mod_map_from_binary(ModMapBin) ->
-    binary_to_term(ModMapBin).
 
 %% ===================================================================
 %% EUnit tests


### PR DESCRIPTION
See results here for facile test https://gist.github.com/russelldb/d330d796ca1b25d1879d

The `compression` option is configurable. Defaults to `1`. I still need to cuttlefish this, or at least add it to advanced.config for riak.
