### PR TITLE
Move all version / tag information to a single location

### DIFF
--- a/include/riak_dt_tags.hrl
+++ b/include/riak_dt_tags.hrl
@@ -1,0 +1,35 @@
+%%% Tags for all our riak_dt CRDTs.
+%%%
+%%% Versions still live in the files themselves, allowing each data type to
+%%% decide when it's a different version on its own.
+%%%
+%%% The simplest thing to do is this: when adding a new data type, insert a new
+%%% line in this file with a unique tag number (trying to keep the file
+%%% organised). Then in the riak_dt_<type>.erl file, have a line like so:
+%%%
+%%%   -define(TAG, ?DT_<type>_TAG).
+%%% 
+%%% Then use ?TAG in the to_/from_binary kerfuffle.
+
+%% Flags
+-define(DT_ENABLE_FLAG_TAG, 79).
+-define(DT_DISABLE_FLAG_TAG, 80).
+-define(DT_OD_FLAG_TAG, 73).
+-define(DT_OE_FLAG_TAG, 74).
+
+%% Registers
+-define(DT_LWWREG_TAG, 72).
+
+%% Counters
+-define(DT_GCOUNTER_TAG, 70).
+-define(DT_PNCOUNTER_TAG, 71).
+
+%% Sets
+-define(DT_GSET_TAG, 82).
+-define(DT_ORSET_TAG, 76).
+-define(DT_ORSWOT_TAG, 75).
+
+%% Maps
+-define(DT_MAP_TAG, 77).
+
+%% Other

--- a/include/riak_dt_tags.hrl
+++ b/include/riak_dt_tags.hrl
@@ -7,6 +7,7 @@
 %%% line in this file with a unique tag number (trying to keep the file
 %%% organised). Then in the riak_dt_<type>.erl file, have a line like so:
 %%%
+%%%   -include("riak_dt_tags.hrl").
 %%%   -define(TAG, ?DT_<type>_TAG).
 %%% 
 %%% Then use ?TAG in the to_/from_binary kerfuffle.

--- a/src/riak_dt_disable_flag.erl
+++ b/src/riak_dt_disable_flag.erl
@@ -40,7 +40,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--define(TAG, 80).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_DISABLE_FLAG_TAG).
 
 -export_type([disable_flag/0]).
 -opaque disable_flag() :: on | off.

--- a/src/riak_dt_enable_flag.erl
+++ b/src/riak_dt_enable_flag.erl
@@ -40,7 +40,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--define(TAG, 79).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_ENABLE_FLAG_TAG).
 
 -export_type([enable_flag/0]).
 -opaque enable_flag() :: on | off.

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -112,7 +112,8 @@ stat(actor_count, GCnt) ->
     length(GCnt);
 stat(_,_) -> undefined.
 
--define(TAG, 70).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_GCOUNTER_TAG).
 -define(V1_VERS, 1).
 
 %% @doc Encode an effecient binary representation of a `gcounter()'

--- a/src/riak_dt_gset.erl
+++ b/src/riak_dt_gset.erl
@@ -90,7 +90,8 @@ merge(GSet1, GSet2) ->
 equal(GSet1, GSet2) ->
     GSet1 == GSet2.
 
--define(TAG, 82).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_GSET_TAG).
 -define(V1_VERS, 1).
 
 -spec to_binary(gset()) -> binary_gset().

--- a/src/riak_dt_lwwreg.erl
+++ b/src/riak_dt_lwwreg.erl
@@ -122,8 +122,8 @@ stat(value_size, {Value,_}=_LWW) ->
     erlang:external_size(Value);
 stat(_, _) -> undefined.
 
-
--define(TAG, 72).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_LWWREG_TAG).
 -define(V1_VERS, 1).
 
 %% @doc Encode an effecient binary representation of an `lwwreg()'

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -301,7 +301,8 @@ stat(max_dot_length, {_, Fields}) ->
                  end, 0, Fields);
 stat(_,_) -> undefined.
 
--define(TAG, 77).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_MAP_TAG).
 -define(V1_VERS, 1).
 
 %% @doc returns a binary representation of the provided `map()'. The

--- a/src/riak_dt_od_flag.erl
+++ b/src/riak_dt_od_flag.erl
@@ -99,8 +99,8 @@ stat(actor_count, {C, _}) ->
     length(C);
 stat(_, _) -> undefined.
 
-
--define(TAG, 73).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_OD_FLAG_TAG).
 -define(VSN1, 1).
 
 -spec from_binary(binary()) -> od_flag().

--- a/src/riak_dt_oe_flag.erl
+++ b/src/riak_dt_oe_flag.erl
@@ -90,7 +90,8 @@ equal({C1,F},{C2,F}) ->
     riak_dt_vclock:equal(C1,C2);
 equal(_,_) -> false.
 
--define(TAG, 74).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_OE_FLAG_TAG).
 -define(VSN1, 1).
 
 -spec from_binary(binary()) -> oe_flag().

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -153,7 +153,8 @@ stat(waste_pct, ORSet) ->
     end;
 stat(_, _) -> undefined.
 
--define(TAG, 76).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_ORSET_TAG).
 -define(V1_VERS, 1).
 
 -spec to_binary(orset()) -> binary_orset().

--- a/src/riak_dt_orswot.erl
+++ b/src/riak_dt_orswot.erl
@@ -306,7 +306,8 @@ stat(max_dot_length, {_Clock, Dict}) ->
                  end, 0, Dict);
 stat(_,_) -> undefined.
 
--define(TAG, 75).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_ORSWOT_TAG).
 -define(V1_VERS, 1).
 
 %% @doc returns a binary representation of the provided

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -146,7 +146,8 @@ stat(actor_count, PNCounter) ->
 stat(_, _) -> undefined.
 
 
--define(TAG, 71).
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_PNCOUNTER_TAG).
 -define(V1_VERS, 1).
 -define(V2_VERS, 2).
 


### PR DESCRIPTION
Currently the to/from binary stuff is per file, the macros for version / tag should be in a single location, if just because adding a new one means looking in every file.

riak_dt.hrl seems like the logical place.

maybe a macro like ?TAG(?MODULE) would do it?
