### PR TITLE
orswot doesn't remove deleted entries on merge

### DIFF
--- a/src/riak_dt_orswot.erl
+++ b/src/riak_dt_orswot.erl
@@ -134,9 +134,10 @@ update({update, Ops}, Actor, ORSet) ->
     apply_ops(lists:sort(Ops), Actor, ORSet);
 update({add, Elem}, Actor, ORSet) ->
     {ok, add_elem(Actor, ORSet, Elem)};
-update({remove, Elem}, _Actor, ORSet) ->
-    {_Clock, Entries} = ORSet,
-    remove_elem(orddict:find(Elem, Entries), Elem, ORSet);
+update({remove, Elem}, Actor, ORSet) ->
+    {Clock, Entries} = ORSet,
+    NewClock = riak_dt_vclock:increment(Actor, Clock),
+    remove_elem(orddict:find(Elem, Entries), Elem, {NewClock, Entries});
 update({add_all, Elems}, Actor, ORSet) ->
     ORSet2 = lists:foldl(fun(E, S) ->
                                  add_elem(Actor, S, E) end,

--- a/src/riak_dt_orswot.erl
+++ b/src/riak_dt_orswot.erl
@@ -352,6 +352,15 @@ stat_test() ->
     ?assertEqual(1, stat(max_dot_length, Set4)),
     ?assertEqual(undefined, stat(waste_pct, Set4)).
 
+disjoint_merge_test() ->
+    {ok, A1} = update({add, <<"foo">>}, 1, new()),
+    {ok, A2} = update({add, <<"bar">>}, 1, A1),
+    {ok, B1} = update({add, <<"baz">>}, 2, new()),
+    C = merge(A2, B1),
+    {ok, A3} = update({remove, <<"bar">>}, 1, A2),
+    D = merge(A3, C),
+    ?assertEqual([<<"baz">>,<<"foo">>], value(D)).
+
 -ifdef(EQC).
 
 bin_roundtrip_test_() ->


### PR DESCRIPTION
The `riak_dt_orswot` CRDT keeps deleted entries after they've been removed if the clocks haven't been incremented by an add operation. Example test case:

```
    {ok, A1} = riak_dt_orswot:update({add, <<"foo">>}, 1, riak_dt_orswot:new()),
    {ok, A2} = riak_dt_orswot:update({add, <<"bar">>}, 1, A1),
    {ok, B1} = riak_dt_orswot:update({add, <<"baz">>}, 2, riak_dt_orswot:new()),
    C = riak_dt_orswot:merge(A2, B1),
    {ok, A3} = riak_dt_orswot:update({remove, <<"bar">>}, 1, A2),
    D = riak_dt_orswot:merge(A3, C),
    % Actual return value is [<<"bar">>,<<"baz">>,<<"quux">>]
    [<<"baz">>,<<"foo">>] == riak_dt_orswot:value(D).
```
