### PR TITLE
Add the `parent_clock` call on update to the Model for map_eqc

### DIFF
--- a/test/map_eqc.erl
+++ b/test/map_eqc.erl
@@ -343,11 +343,11 @@ model_new() ->
 model_add_field({_Name, Type}=Field, Actor, Cnt, Model) ->
     #model{adds=Adds, clock=Clock} = Model,
     {ok, Model#model{adds=sets:add_element({Field, Type:new(), Cnt}, Adds),
-                     clock=riak_dt_vclock:increment(Actor, Clock)}}.
+                     clock=riak_dt_vclock:merge([[{Actor, Cnt}], Clock])}}.
 
 model_update_field({_Name, Type}=Field, Op, Actor, Cnt, Model) ->
     #model{adds=Adds, removes=Removes, clock=Clock} = Model,
-    Clock2 = riak_dt_vclock:increment(Actor, Clock),
+    Clock2 = riak_dt_vclock:merge([[{Actor, Cnt}], Clock]),
     InMap = sets:subtract(Adds, Removes),
     {CRDT0, ToRem} = lists:foldl(fun({F, Value, _X}=E, {CAcc, RAcc}) when F == Field ->
                                          {Type:merge(CAcc, Value), sets:add_element(E, RAcc)};

--- a/test/map_eqc.erl
+++ b/test/map_eqc.erl
@@ -186,12 +186,13 @@ ctx_remove_pre(S=#state{replica_data=ReplicaData, adds=Adds}) ->
     replicas_ready(S) andalso Adds /= [] andalso ReplicaData /= [].
 
 ctx_remove_args(#state{replicas=Replicas, replica_data=ReplicaData, adds=Adds}) ->
-    [
-     elements(Replicas), %% read from
-     elements(Replicas), %% send op too
-     ?LET({_,X}, elements(Adds), X), %% which field to remove
-     ReplicaData %% All the vnode data
-    ].
+    ?LET({{From, Field}, To}, {elements(Adds), elements(Replicas)},
+         [
+          From,        %% read from
+          To,          %% send op to
+          Field,       %% which field to remove
+          ReplicaData  %% All the vnode data
+         ]).
 
 %% Should we send ctx ops to originating replica?
 ctx_remove_pre(_S, [VN, VN, _, _]) ->


### PR DESCRIPTION
When the map performs an update to a field,it replaces the embedded
crdt's clock with it's own. It does this because context operations
on fields in a map take the maps context.

This leads to a neat semantic change: when you remove a set or flag,
and then re-add it by updating, the new entry gets the Maps clock,
which means it has seen all the elements that were removed by removing
the field. This leads to a defacto reset-remove semantic for sets and
flags. Assuming time goes forward the same is true for lwwreg. Only
counters have a strange semantic on field remove | re-add now.

Note: just _adding_ the field does not lead to this behaviour, only
and update causes the clock to be replaced. Otherwise an `add` to a
field that is present would be short hand for "remove, then add"
(which maybe it should be??)
