### PR TITLE
Add embedded ctx operations to map_eqc

### DIFF
--- a/src/riak_dt_orswot.erl
+++ b/src/riak_dt_orswot.erl
@@ -163,8 +163,8 @@ update({remove_all, Elems}, Actor, ORSet) ->
 update(Op, Actor, ORSet, undefined) ->
     update(Op, Actor, ORSet);
 update({add, Elem}, Actor, ORSet, _Ctx) ->
-    ORSet = add_elem(Actor, ORSet, Elem),
-    {ok, ORSet};
+    ORSet2 = add_elem(Actor, ORSet, Elem),
+    {ok, ORSet2};
 update({remove, Elem}, _Actor, {Clock, Entries, Deferred}, Ctx) ->
     %% Being asked to remove something with a context.  If we
     %% have this element, we can drop any dots it has that the


### PR DESCRIPTION
Fix riak_dt_orswot bug found by same

```
OK, passed 1000000 tests

17.45167% {map_eqc,ctx_update,5}
17.44523% {map_eqc,update,4}
17.41366% {map_eqc,add,4}
13.68039% {map_eqc,replicate,3}
10.01635% {map_eqc,make_ring,2}
9.51253% {map_eqc,remove,2}
8.34556% {map_eqc,ctx_remove,4}
6.13462% {map_eqc,set_n,1}
true
```
