### PR TITLE
Make sure all data types use configured compression in t2b/b2t

### DIFF
--- a/src/riak_dt.erl
+++ b/src/riak_dt.erl
@@ -22,6 +22,7 @@
 
 -module(riak_dt).
 
+-export([to_binary/1, from_binary/1]).
 -export_type([actor/0, dot/0, crdt/0, context/0]).
 
 -type crdt() :: term().
@@ -60,3 +61,16 @@
 -callback init_state() -> model_state().
 
 -endif.
+
+-spec to_binary(crdt()) -> binary().
+to_binary(Term) ->
+    Opts = case application:get_env(riak_dt, binary_compression, 1) of
+               true -> [compressed];
+               N when N >= 0, N =< 9 -> [{compressed, N}];
+               _ -> []
+           end,
+    term_to_binary(Term, Opts).
+
+-spec from_binary(binary()) -> crdt().
+from_binary(Binary) ->
+    binary_to_term(Binary).

--- a/src/riak_dt_lwwreg.erl
+++ b/src/riak_dt_lwwreg.erl
@@ -136,39 +136,13 @@ stat(_, _) -> undefined.
 
 %% @doc Encode an effecient binary representation of an `lwwreg()'
 -spec to_binary(lwwreg()) -> binary().
-to_binary({Val, TS}) ->
-    {ValueLen, ValueBin} = val_to_binary(Val),
-    {TSLen, TSBin} = ts_to_binary(TS),
-    <<?TAG:8/integer, ?V1_VERS:8/integer, ValueLen:8/integer, ValueBin/binary, TSLen:8/integer, TSBin/binary>>.
+to_binary(LWWReg) ->
+    <<?TAG:8/integer, ?V1_VERS:8/integer, (riak_dt:to_binary(LWWReg))/binary>>.
 
 %% @doc Decode binary `lwwreg()'
 -spec from_binary(binary()) -> lwwreg().
-from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, ValueLen:8/integer, ValueBin:ValueLen/binary,
-              TSLen:8/integer, TSBin:TSLen/binary>>) ->
-    {binary_to_val(ValueBin), binary_to_ts(TSBin)}.
-
-val_to_binary(Val) when is_binary(Val) ->
-    Bin = <<1, Val/binary>>,
-    {byte_size(Bin), Bin};
-val_to_binary(Term) ->
-    Bin = <<0, (term_to_binary(Term))/binary>>,
-    {byte_size(Bin), Bin}.
-
-binary_to_val(<<1, Val/binary>>) ->
-    Val;
-binary_to_val(<<0, Val/binary>>) ->
-    binary_to_term(Val).
-
-binary_to_ts(<<1, TS/binary>>) ->
-    binary:decode_unsigned(TS);
-binary_to_ts(TS) ->
-    binary_to_val(TS).
-
-ts_to_binary(TS) when is_integer(TS) ->
-    Bin = <<1, (binary:encode_unsigned(TS))/binary>>,
-    {byte_size(Bin), Bin};
-ts_to_binary(TS) ->
-    val_to_binary(TS).
+from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
+    riak_dt:from_binary(Bin).
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -449,12 +449,7 @@ stat(_,_) -> undefined.
 %% @see `from_binary/1'
 -spec to_binary(map()) -> binary_map().
 to_binary(Map) ->
-    Opts = case application:get_env(riak_dt, binary_compression, 1) of
-               true -> [compressed];
-               N when N >= 0, N =< 9 -> [{compressed, N}];
-               _ -> []
-           end,
-    <<?TAG:8/integer, ?V1_VERS:8/integer, (term_to_binary(Map, Opts))/binary>>.
+    <<?TAG:8/integer, ?V1_VERS:8/integer, (riak_dt:to_binary(Map))/binary>>.
 
 %% @doc When the argument is a `binary_map()' produced by
 %% `to_binary/1' will return the original `map()'.
@@ -462,7 +457,7 @@ to_binary(Map) ->
 %% @see `to_binary/1'
 -spec from_binary(binary_map()) -> map().
 from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, B/binary>>) ->
-    binary_to_term(B).
+    riak_dt:from_binary(B).
 
 
 %% ===================================================================

--- a/src/riak_dt_od_flag.erl
+++ b/src/riak_dt_od_flag.erl
@@ -174,12 +174,11 @@ stat(_, _) -> undefined.
 
 -spec from_binary(binary()) -> od_flag().
 from_binary(<<?TAG:8, ?VSN1:8, Bin/binary>>) ->
-    binary_to_term(Bin).
+    riak_dt:from_binary(Bin).
 
 -spec to_binary(od_flag()) -> binary().
 to_binary(Flag) ->
-    Bin = term_to_binary(Flag),
-    <<?TAG:8, ?VSN1:8, Bin/binary>>.
+    <<?TAG:8, ?VSN1:8, (riak_dt:to_binary(Flag))/binary>>.
 
 %% @doc the `precondition_context' is an opaque piece of state that
 %% can be used for context operations to ensure only observed state is

--- a/src/riak_dt_orswot.erl
+++ b/src/riak_dt_orswot.erl
@@ -443,12 +443,7 @@ stat(_,_) -> undefined.
 %% @see `from_binary/1'
 -spec to_binary(orswot()) -> binary_orswot().
 to_binary(S) ->
-    Opts = case application:get_env(riak_dt, binary_compression, true) of
-               true -> [{compressed, 1}];
-               N when N >= 0, N =< 9 -> [{compressed, N}];
-               _ -> []
-           end,
-     <<?TAG:8/integer, ?V1_VERS:8/integer, (term_to_binary(S, Opts))/binary>>.
+     <<?TAG:8/integer, ?V1_VERS:8/integer, (riak_dt:to_binary(S))/binary>>.
 
 %% @doc When the argument is a `binary_orswot()' produced by
 %% `to_binary/1' will return the original `orswot()'.
@@ -456,7 +451,7 @@ to_binary(S) ->
 %% @see `to_binary/1'
 -spec from_binary(binary_orswot()) -> orswot().
 from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, B/binary>>) ->
-    binary_to_term(B).
+    riak_dt:from_binary(B).
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -178,8 +178,7 @@ from_binary(Binary = <<?TAG:8/integer, _/binary>>) ->
 to_binary(?V2_VERS, PNCnt) ->
     Version = current_version(PNCnt),
     V2 = change_versions(Version, ?V2_VERS, PNCnt),
-    V2Bin = term_to_binary(V2),
-    <<?TAG:8/integer, ?V2_VERS:8/integer, V2Bin/binary>>;
+    <<?TAG:8/integer, ?V2_VERS:8/integer, (riak_dt:to_binary(V2))/binary>>;
 to_binary(?V1_VERS, PNCnt) ->
     Version = current_version(PNCnt),
     {P,N} = change_versions(Version, ?V1_VERS, PNCnt),
@@ -193,7 +192,7 @@ to_binary(?V1_VERS, PNCnt) ->
 
 -spec from_binary(version(), binary()) -> any_pncounter().
 from_binary(?V2_VERS, <<?TAG:8/integer, ?V2_VERS:8/integer, PNBin/binary>>) ->
-    binary_to_term(PNBin);
+    riak_dt:from_binary(PNBin);
 from_binary(?V1_VERS, <<?TAG:8/integer, ?V1_VERS:8/integer,
                   PBinLen:32/integer, PBin:PBinLen/binary,
                   NBinLen:32/integer, NBin:NBinLen/binary>>) ->


### PR DESCRIPTION
For 2.0 release (map and orswot currently use compression):
- [x] lwwreg (only ever in map, which never calls to_binary/1 in lwwreg)
- [x] od-flag (only ever in map, which never calls to_binary/1 in od-flag)
- [x] pn-counter (we've kinda looked at this, but compression might do better)

For later:
- [ ] gcounter
- [ ] gset
- [ ] oe-flag
- [ ] orset
