### PR TITLE
Use testing_time in favor of numtests in eunit tests

### DIFF
--- a/test/map_eqc.erl
+++ b/test/map_eqc.erl
@@ -55,7 +55,7 @@
                               io:format(user, Str, Args) end, P)).
 
 eqc_test_() ->
-    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:numtests(1000, ?QC_OUT(prop_merge()))))}.
+    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(prop_merge()))))}.
 
 run() ->
     run(?NUMTESTS).

--- a/test/od_flag_eqc.erl
+++ b/test/od_flag_eqc.erl
@@ -51,7 +51,7 @@
                               io:format(user, Str, Args) end, P)).
 
 eqc_test_() ->
-    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:numtests(1000, ?QC_OUT(prop_merge()))))}.
+    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(prop_merge()))))}.
 
 run() ->
     run(?NUMTESTS).

--- a/test/orswot_eqc.erl
+++ b/test/orswot_eqc.erl
@@ -53,7 +53,7 @@
                               io:format(user, Str, Args) end, P)).
 
 eqc_test_() ->
-    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:numtests(1000, ?QC_OUT(prop_merge()))))}.
+    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(prop_merge()))))}.
 
 run() ->
     run(?NUMTESTS).


### PR DESCRIPTION
This helps the tests avoid timing out on slower (read buildbot)
machines.
