### PR TITLE
Reset-remove semantic on Map

### DIFF
--- a/include/riak_dt_tags.hrl
+++ b/include/riak_dt_tags.hrl
@@ -9,7 +9,7 @@
 %%%
 %%%   -include("riak_dt_tags.hrl").
 %%%   -define(TAG, ?DT_<type>_TAG).
-%%% 
+%%%
 %%% Then use ?TAG in the to_/from_binary kerfuffle.
 
 %% Flags
@@ -24,6 +24,7 @@
 %% Counters
 -define(DT_GCOUNTER_TAG, 70).
 -define(DT_PNCOUNTER_TAG, 71).
+-define(DT_EMCNTR_TAG, 85).
 
 %% Sets
 -define(DT_GSET_TAG, 82).

--- a/src/riak_dt.erl
+++ b/src/riak_dt.erl
@@ -53,12 +53,8 @@
 
 -ifdef(EQC).
 % Extra callbacks for any crdt_statem_eqc tests
--type model_state() :: term().
 
 -callback gen_op() -> eqc_gen:gen(operation()).
--callback update_expected(actor(), operation(), model_state()) -> model_state().
--callback eqc_state_value(model_state()) -> term().
--callback init_state() -> model_state().
 
 -endif.
 

--- a/src/riak_dt_emcntr.erl
+++ b/src/riak_dt_emcntr.erl
@@ -128,9 +128,11 @@ op(increment, {P, N}) ->
     {P+1, N};
 op(decrement, {P, N}) ->
     {P, N+1};
-op({increment, By}, {P, N}) ->
+op({_Op, 0}, {P, N}) ->
+    {P, N};
+op({increment, By}, {P, N}) when is_integer(By), By > 0 ->
     {P+By, N};
-op({decrement, By}, {P, N}) ->
+op({decrement, By}, {P, N}) when is_integer(By), By > 0 ->
     {P, N+By}.
 
 %% @doc takes two `emcntr()'s and merges them into a single
@@ -261,8 +263,7 @@ gen_op() ->
     oneof([increment,
            {increment, nat()},
            decrement,
-           {decrement, nat()},
-           {increment, ?LET(X, nat(), -X)}
+           {decrement, nat()}
           ]).
 
 update_expected(_ID, increment, Prev) ->

--- a/src/riak_dt_emcntr.erl
+++ b/src/riak_dt_emcntr.erl
@@ -1,0 +1,390 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_dt_emcntr: A convergent, replicated, state based PN counter,
+%% for embedding in riak_dt_map.
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc A PN-Counter CRDT. A PN-Counter is essentially two G-Counters:
+%% one for increments and one for decrements. The value of the counter
+%% is the difference between the value of the Positive G-Counter and
+%% the value of the Negative G-Counter. However, this PN-Counter is
+%% for using embedded in a riak_dt_map. The problem with an embedded
+%% pn-counter is when the field is removed and added again. PN-Counter
+%% merge takes the max of P and N as the merged value. In the case
+%% that a field was removed and re-added P and N maybe be _lower_ than
+%% their removed values, and when merged with a replica that has not
+%% seen the remove, the remove is lost. This counter adds some
+%% causality by storing a `dot` with P and N. Merge takes the max
+%% event for each actor, so newer values win over old ones. The rest
+%% of the mechanics are the same.
+%%
+%% @see riak_kv_gcounter.erl
+%%
+%% @reference Marc Shapiro, Nuno Preguiça, Carlos Baquero, Marek Zawirski (2011) A comprehensive study of
+%% Convergent and Commutative Replicated Data Types. http://hal.upmc.fr/inria-00555588/
+%%
+%% @end
+
+-module(riak_dt_emcntr).
+-behaviour(riak_dt).
+
+-export([new/0, value/1, value/2]).
+-export([update/3, merge/2, equal/2]).
+-export([to_binary/1, from_binary/1]).
+-export([stats/1, stat/2]).
+-export([parent_clock/2, update/4]).
+
+%% EQC API
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-export([gen_op/0, update_expected/3, eqc_state_value/1, init_state/0, generate/0]).
+-endif.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-type emcntr() :: {riak_dt_vclock:vclock(), [entry()]}.
+-type entry() :: {Actor :: riak_dt:actor(), {Event :: pos_integer(),
+                                             Inc :: pos_integer(),
+                                             Dec :: pos_integer()}
+                 }.
+
+-spec new() -> emcntr().
+new() ->
+    {riak_dt_vclock:fresh(), orddict:new()}.
+
+%% @doc embedded CRDTs most share a causal context with their parent
+%% Map, setting the internal clock to the parent clock ensures this
+-spec parent_clock(riak_dt_vclock:vclock(), emcntr()) -> emcntr().
+parent_clock(Clock, {_, Cntr}) ->
+    {Clock, Cntr}.
+
+%% @doc the current integer value of the counter
+-spec value(emcntr()) -> integer().
+value({_Clock, PNCnt}) ->
+    lists:sum([Inc - Dec || {_Act, {_Event, Inc, Dec}} <- PNCnt]).
+
+%% @doc query value, not implemented. Just returns result of `value/1'
+-spec value(term(), emcntr()) -> integer().
+value(_, Cntr) ->
+    value(Cntr).
+
+%% @doc increment/decrement the counter. Op is either a two tuple of
+%% `{increment, By}', `{decrement, By}' where `By' is a positive
+%% integer. Or simply the atoms `increment' or `decrement', which are
+%% equivalent to `{increment | decrement, 1}' Returns the updated
+%% counter.
+%%
+%% Note: the second argument must be a `riak_dt:dot()', that is a
+%% 2-tuple of `{Actor :: term(), Event :: pos_integer()}' as this is
+%% for embedding in a `riak_dt_map'
+-spec update(emcntr_op(), riak_dt:dot(), emcntr()) -> {ok, emcntr()}.
+update(Op, {Actor, Evt}=Dot, {Clock, PNCnt}) when is_tuple(Dot) ->
+    Clock2 = riak_dt_vclock:merge([[Dot], Clock]),
+    Entry = orddict:find(Actor, PNCnt),
+    {Inc, Dec} = op(Op, Entry),
+    {ok, {Clock2, orddict:store(Actor, {Evt, Inc, Dec}, PNCnt)}}.
+
+%% @doc update with a context. Contexts have no effect. Same as
+%% `update/3'
+-spec update(emcntr_op(), riak_dt:dot(), emcntr(), riak_dt_vclock:vclock()) ->
+                    {ok, emcntr()}.
+update(Op, Dot, Cntr, _Ctx) ->
+    update(Op, Dot, Cntr).
+
+%% @private perform the operation `Op' on the {positive, negative}
+%% pair for an actor.
+-spec op(emcntr_op(), error | {ok, entry()} | {P::non_neg_integer(), N::non_neg_integer()}) ->
+                {P::non_neg_integer(), N::non_neg_integer()}.
+op(Op, error) ->
+    op(Op, {0, 0});
+op(Op, {ok, {_Evt, P, N}}) ->
+    op(Op, {P, N});
+op(increment, {P, N}) ->
+    {P+1, N};
+op(decrement, {P, N}) ->
+    {P, N+1};
+op({increment, By}, {P, N}) ->
+    {P+By, N};
+op({decrement, By}, {P, N}) ->
+    {P, N+By}.
+
+%% @doc takes two `emcntr()'s and merges them into a single
+%% `emcntr()'. This is the Least Upper Bound of the Semi-Lattice/CRDT
+%% literature. The semantics of the `emnctr()' merge are explained in
+%% the module docs. In a nutshell, merges version vectors, and keeps
+%% only dots that are present on both sides, or concurrent.
+-spec merge(emcntr(), emcntr()) -> emcntr().
+merge(Cnt, Cnt) ->
+    Cnt;
+merge({ClockA, CntA}, {ClockB, CntB}) ->
+    Clock = riak_dt_vclock:merge([ClockA, ClockB]),
+    {Cnt0, BUnique} = merge_left(ClockB, CntA, CntB),
+    Cnt = merge_right(ClockA, BUnique, Cnt0),
+    {Clock, Cnt}.
+
+%% @private merge the left handside counter (A) by filtering out the
+%% dots that are unique to it, and dominated. Returns `[entry()]' as
+%% an accumulator, and the dots that are unique to the right hand side
+%% (B).
+-spec merge_left(riak_dt_vclock:vclock(), [entry()], [entry()]) -> {[entry()], [entry()]}.
+merge_left(RHSClock, LHS, RHS) ->
+    orddict:fold(fun(Actor, {Evt, _Inc, _Dec}=Cnt, {Keep, RHSUnique}) ->
+                         case orddict:find(Actor, RHS) of
+                             error ->
+                                 case riak_dt_vclock:descends(RHSClock, [{Actor, Evt}]) of
+                                     true ->
+                                         {Keep, RHSUnique};
+                                     false ->
+                                         {orddict:store(Actor, Cnt, Keep), RHSUnique}
+                                 end;
+                             %% RHS has this actor, with a greater dot
+                             {ok, {E2, I, D}} when E2 > Evt ->
+                                 {orddict:store(Actor, {E2, I, D}, Keep), orddict:erase(Actor, RHSUnique)};
+                             %% RHS has this actor, but a lesser or equal dot
+                             {ok, _} ->
+                                 {orddict:store(Actor, Cnt, Keep), orddict:erase(Actor, RHSUnique)}
+                         end
+                 end,
+                 {orddict:new(), RHS},
+                 LHS).
+
+%% @private merge the unique actor entries from the right hand side,
+%% keeping the concurrent ones, and dropping the dominated.
+-spec merge_right(riak_dt_vclock:vclock(), [entry()], [entry()]) -> [entry()].
+merge_right(LHSClock, RHSUnique, Acc) ->
+    orddict:fold(fun(Actor, {Evt, _Inc, _Dec}=Cnt, Keep) ->
+                         case riak_dt_vclock:descends(LHSClock, [{Actor, Evt}]) of
+                             true ->
+                                 Keep;
+                             false ->
+                                 orddict:store(Actor, Cnt, Keep)
+                         end
+                 end,
+                 Acc,
+                 RHSUnique).
+
+%% @doc equality of two counters internal structure, not the `value/1'
+%% they produce.
+-spec equal(emcntr(), emcntr()) -> boolean().
+equal({ClockA, PNCntA}, {ClockB, PNCntB}) ->
+    riak_dt_vclock:equal(ClockA, ClockB) andalso
+        PNCntA =:= PNCntB.
+
+%% @doc generate stats for this counter. Only `actor_count' is
+%% produced at present.
+-spec stats(emcntr()) -> [{actor_count, pos_integer()}].
+stats(Emcntr) ->
+    [{actor_count, stat(actor_count, Emcntr)}].
+
+%% @doc generate stat for requested stat type at first argument. Only
+%% `actor_count' is supported at present.  Return a `pos_integer()' for
+%% the stat requested, or `undefined' if stat type is unsupported.
+-spec stat(atom(), emcntr()) -> pos_integer() | undefined.
+stat(actor_count, {Clock, _Emcntr}) ->
+    length(Clock);
+stat(_, _) -> undefined.
+
+-include("riak_dt_tags.hrl").
+-define(TAG, ?DT_EMCNTR_TAG).
+-define(V1_VERS, 1).
+
+%% @doc produce a compact binary representation of the counter.
+%%
+%% @see from_binary/1
+-spec to_binary(emcntr()) -> binary().
+to_binary(Cntr) ->
+    Bin = term_to_binary(Cntr),
+    <<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>.
+
+%% @doc Decode a binary encoded riak_dt_emcntr.
+%%
+%% @see to_binary/1
+-spec from_binary(binary()) -> emcntr().
+from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, Bin/binary>>) ->
+    binary_to_term(Bin).
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+-ifdef(EQC).
+%% EQC generator
+generate() ->
+    ?LET({Ops, Actors}, {non_empty(list(gen_op())), non_empty(list(bitstring(16*8)))},
+         begin
+             {Generated, _Evts} = lists:foldl(fun(Op, {Cntr, Evt}) ->
+                                                      Actor = case length(Actors) of
+                                                                  1 -> hd(Actors);
+                                                                  _ -> lists:nth(crypto:rand_uniform(1, length(Actors)+1), Actors)
+                                                              end,
+                                                      {ok, Cntr2} = riak_dt_emcntr:update(Op, {Actor, Evt}, Cntr),
+                                                      {Cntr2, Evt+1}
+                                              end,
+                                              {riak_dt_emcntr:new(), 1},
+                                              Ops),
+             Generated
+         end).
+
+init_state() ->
+    0.
+
+gen_op() ->
+    oneof([increment,
+           {increment, nat()},
+           decrement,
+           {decrement, nat()},
+           {increment, ?LET(X, nat(), -X)}
+          ]).
+
+update_expected(_ID, increment, Prev) ->
+    Prev+1;
+update_expected(_ID, decrement, Prev) ->
+    Prev-1;
+update_expected(_ID, {increment, By}, Prev) ->
+    Prev+By;
+update_expected(_ID, {decrement, By}, Prev) ->
+    Prev-By;
+update_expected(_ID, _Op, Prev) ->
+    Prev.
+
+eqc_state_value(S) ->
+    S.
+-endif.
+
+new_test() ->
+    ?assertEqual(0, value(new())).
+
+make_counter(Ops, Evt) ->
+    lists:foldl(fun({Actor, Op}, {Counter, Event}) ->
+                        E2 = Event+1,
+                        {ok, C2} = update(Op, {Actor, E2}, Counter),
+                        {C2, E2} end,
+                {new(), Evt},
+                Ops).
+
+make_counter(Ops) ->
+    {Cnt, _Evt} = make_counter(Ops, 0),
+    Cnt.
+
+value_test() ->
+    PNCnt1 = make_counter([{a, increment},
+                           {b, {increment, 13}}, {b, {decrement, 10}},
+                           {c, increment},
+                           {d, decrement}]),
+    PNCnt2 = make_counter([]),
+    PNCnt3 = make_counter([{a, {increment,3}}, {a, {decrement, 3}},
+                           {b, decrement}, {b, increment},
+                           {c, increment}, {c, decrement}]),
+    ?assertEqual(4, value(PNCnt1)),
+    ?assertEqual(0, value(PNCnt2)),
+    ?assertEqual(0, value(PNCnt3)).
+
+update_increment_test() ->
+    PNCnt0 = new(),
+    {ok, PNCnt1} = update(increment, {a, 1}, PNCnt0),
+    {ok, PNCnt2} = update(increment, {b, 1}, PNCnt1),
+    {ok, PNCnt3} = update(increment, {a, 2}, PNCnt2),
+    ?assertEqual(3, value(PNCnt3)).
+
+update_increment_by_test() ->
+    PNCnt0 = new(),
+    {ok, PNCnt1} = update({increment, 7}, {a, 1}, PNCnt0),
+    ?assertEqual(7, value(PNCnt1)).
+
+update_decrement_test() ->
+    PNCnt0 = new(),
+    {ok, PNCnt1} = update(increment, {a, 1}, PNCnt0),
+    {ok, PNCnt2} = update(increment, {b, 1}, PNCnt1),
+    {ok, PNCnt3} = update(increment, {a, 2}, PNCnt2),
+    {ok, PNCnt4} = update(decrement, {a, 3}, PNCnt3),
+    ?assertEqual(2, value(PNCnt4)).
+
+update_decrement_by_test() ->
+    PNCnt0 = new(),
+    {ok, PNCnt1} = update({increment, 7}, {a, 1}, PNCnt0),
+    {ok, PNCnt2} = update({decrement, 5}, {a, 2}, PNCnt1),
+    ?assertEqual(2, value(PNCnt2)).
+
+merge_test() ->
+    {PNCnt1, Evt} = make_counter([{<<"1">>, increment},
+                           {<<"2">>, {increment, 2}},
+                           {<<"4">>, {increment, 1}}], 0),
+    {PNCnt2, _Evt2} = make_counter([{<<"3">>, {increment, 3}},
+                           {<<"4">>, {increment, 3}}], Evt),
+    ?assertEqual(new(), merge(new(), new())),
+    ?assertEqual(9, value(merge(PNCnt1, PNCnt2))).
+
+equal_test() ->
+    PNCnt1 = make_counter([{1, {increment, 2}}, {1, decrement},
+                           {2, increment},
+                           {3, decrement},
+                           {4, increment}]),
+    PNCnt2 = make_counter([{1, increment},
+                           {2, {increment, 4}},
+                           {3, increment}]),
+    PNCnt3 = make_counter([{1, {increment, 2}}, {1, decrement},
+                           {2, increment},
+                           {3, decrement},
+                           {4, increment}]),
+    ?assertNot(equal(PNCnt1, PNCnt2)),
+    ?assert(equal(PNCnt1, PNCnt3)).
+
+usage_test() ->
+    PNCnt1 = new(),
+    PNCnt2 = new(),
+    ?assert(equal(PNCnt1, PNCnt2)),
+    {ok, PNCnt1_1} = update({increment, 2}, {a1, 1}, PNCnt1),
+    {ok, PNCnt2_1} = update(increment, {a2, 1}, PNCnt2),
+    PNCnt3 = merge(PNCnt1_1, PNCnt2_1),
+    {ok, PNCnt2_2} = update({increment, 3}, {a3, 1}, PNCnt2_1),
+    {ok, PNCnt3_1} = update(increment, {a4, 1}, PNCnt3),
+    {ok, PNCnt3_2} = update(increment, {a1, 2}, PNCnt3_1),
+    {ok, PNCnt3_3} = update({decrement, 2}, {a5, 1}, PNCnt3_2),
+    {ok, PNCnt2_3} = update(decrement, {a2, 2}, PNCnt2_2),
+    ?assertEqual({[{a1, 2}, {a2, 2}, {a3, 1}, {a4, 1}, {a5, 1}],
+                  [{a1, {2, 3,0}},
+                   {a2, {2, 1, 1}},
+                   {a3, {1, 3,0}},
+                   {a4, {1, 1, 0}},
+                   {a5, {1, 0,2}}]}, merge(PNCnt3_3, PNCnt2_3)).
+
+roundtrip_bin_test() ->
+    PN = new(),
+    {ok, PN1} = update({increment, 2}, {<<"a1">>, 1}, PN),
+    {ok, PN2} = update({decrement, 1000000000000000000000000}, {douglas_Actor, 1}, PN1),
+    {ok, PN3} = update(increment, {[{very, ["Complex"], <<"actor">>}, honest], 900987}, PN2),
+    {ok, PN4} = update(decrement, {"another_acotr", 28}, PN3),
+    Bin = to_binary(PN4),
+    Decoded = from_binary(Bin),
+    ?assert(equal(PN4, Decoded)).
+
+stat_test() ->
+    PN = new(),
+    {ok, PN1} = update({increment, 50}, {a1, 1}, PN),
+    {ok, PN2} = update({increment, 50}, {a2, 1}, PN1),
+    {ok, PN3} = update({decrement, 15}, {a3, 1}, PN2),
+    {ok, PN4} = update({decrement, 10}, {a4, 1}, PN3),
+    ?assertEqual([{actor_count, 0}], stats(PN)),
+    ?assertEqual(4, stat(actor_count, PN4)),
+    ?assertEqual(undefined, stat(max_dot_length, PN4)).
+-endif.

--- a/src/riak_dt_emcntr.erl
+++ b/src/riak_dt_emcntr.erl
@@ -54,7 +54,7 @@
 %% EQC API
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--export([gen_op/0, update_expected/3, eqc_state_value/1, init_state/0, generate/0]).
+-export([gen_op/0, gen_op/1, update_expected/3, eqc_state_value/1, init_state/0, generate/0]).
 -endif.
 
 -ifdef(TEST).
@@ -253,6 +253,9 @@ generate() ->
 
 init_state() ->
     0.
+
+gen_op(_Size) ->
+    gen_op().
 
 gen_op() ->
     oneof([increment,

--- a/src/riak_dt_emcntr.erl
+++ b/src/riak_dt_emcntr.erl
@@ -61,11 +61,17 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+-export_type([emcntr/0, emcntr_op/0]).
+
 -type emcntr() :: {riak_dt_vclock:vclock(), [entry()]}.
 -type entry() :: {Actor :: riak_dt:actor(), {Event :: pos_integer(),
                                              Inc :: pos_integer(),
                                              Dec :: pos_integer()}
                  }.
+
+
+-type emcntr_op() :: riak_dt_gcounter:gcounter_op() | decrement_op().
+-type decrement_op() :: decrement | {decrement, pos_integer()}.
 
 -spec new() -> emcntr().
 new() ->

--- a/src/riak_dt_lwwreg.erl
+++ b/src/riak_dt_lwwreg.erl
@@ -38,7 +38,7 @@
 %% EQC API
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--export([gen_op/0, update_expected/3, eqc_state_value/1, init_state/0, generate/0]).
+-export([gen_op/0, gen_op/1, update_expected/3, eqc_state_value/1, init_state/0, generate/0]).
 -endif.
 
 -ifdef(TEST).
@@ -163,6 +163,9 @@ generate() ->
 
 init_state() ->
     {<<>>, 0}.
+
+gen_op(_Size) ->
+    gen_op().
 
 gen_op() ->
     ?LET(TS, largeint(), {assign, binary(), abs(TS)}).

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -132,12 +132,12 @@
 %%
 %% <h3>Lagging replicas, deferred operations</h3>
 %%
-%% In a system like Riak, a replica is not up-to-date (including,
+%% In a system like Riak, a replica that is not up-to-date (including,
 %% never seen any state for a CRDT) maybe asked to perform an
 %% operation. If no context is given, and the operation is a field
 %% remove, or a "remove" like operation on an embedded CRDT, the
 %% operation may fail with a precondition error (for example, remove a
-%% field that is not present) or succeed and remove for state than
+%% field that is not present) or succeed and remove more state than
 %% intended (a field remove with no context may remove updates unseen
 %% by the client.) When a context is provided, and the Field to be
 %% removed is absent, the Map state stores the context, and Field
@@ -151,7 +151,7 @@
 %% There is a bug with embedded types and deferred operations. Imagine
 %% a client has seen a Map with a Set field, and the set contains {a,
 %% b, c}. The client sends an operation to remove {a} from the set. A
-%% replica that is new takes the operation. It well create a new Map,
+%% replica that is new takes the operation. It will create a new Map,
 %% a Field for the Set, and store the `remove` operation as part of
 %% the Set's state. A client reads this new state, and sends a field
 %% remove operation, that is executed by same replica. Now the

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -407,7 +407,7 @@ key_sets(LHS, RHS) ->
 
 %% @private for a set of dots (that are unique to one side) decide
 %% whether to keep, or drop each.
--spec filter_dots(entries(), orddict:orddict(), riak_dt_vclock:vclock()) -> entries().
+-spec filter_dots(set(), orddict:orddict(), riak_dt_vclock:vclock()) -> entries().
 filter_dots(Dots, CRDTs, Clock) ->
     DotsToKeep = sets:filter(fun(Dot) ->
                                      is_dot_unseen(Dot, Clock)
@@ -729,6 +729,15 @@ stat_test() ->
     ?assertEqual(0, stat(duplication, Map6)),
     {ok, Map7} = update({update, [{remove, {l, riak_dt_lwwreg}}]}, a1, Map6),
     ?assertEqual(5, stat(field_count, Map7)).
+
+equals_test() ->
+    {ok, A} = update({update, [{update, {'X', riak_dt_orswot}, {add, <<"a">>}}, {update, {'X', riak_dt_od_flag}, enable}]}, a, new()),
+    {ok, B} = update({update, [{update, {'Y', riak_dt_orswot}, {add, <<"a">>}}, {update, {'Z', riak_dt_od_flag}, enable}]}, b, new()),
+    ?assert(not equal(A, B)),
+    C = merge(A, B),
+    D = merge(B, A),
+    ?assert(equal(C, D)),
+    ?assert(equal(A, A)).
 
 -ifdef(EQC).
 -define(NUMTESTS, 1000).

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -371,7 +371,7 @@ filter_unique(FieldSet, Entries, Clock, Acc) ->
                               %% create a tombstone since the
                               %% otherside does not have this field,
                               %% it either removed it, or never had
-                              %% it.  If it never had it, the removing
+                              %% it. If it never had it, the removing
                               %% dots in the tombstone will have no
                               %% impact on the value, if the otherside
                               %% removed it, then the removed dots
@@ -494,6 +494,14 @@ equal({Clock1, Values1, Deferred1}, {Clock2, Values2, Deferred2}) ->
 pairwise_equals([], []) ->
     true;
 pairwise_equals([{{Name, Type}, {Dots1, TS1}}| Rest1], [{{Name, Type}, {Dots2, TS2}}|Rest2]) ->
+    %% Tombstones don't need to be equal. When we merge with a map
+    %% where one side is absent, we take the absent sides clock, when
+    %% we merge where both sides have a field, we merge the
+    %% tombstones, and apply deferred. The deferred remove uses a glb
+    %% of the context and the clock, meaning we get a smaller
+    %% tombstone. Both are correct when it comes to determining the
+    %% final value. As long as tombstones are not conflicting (that is
+    %% A == B | A > B | B > A)
     case {orddict:fetch_keys(Dots1) == orddict:fetch_keys(Dots2), Type:equal(TS1, TS2)} of
         {true, true} ->
             pairwise_equals(Rest1, Rest2);

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -70,38 +70,37 @@
 
 %% EQC API
 -ifdef(EQC).
--export([gen_op/0, update_expected/3, eqc_state_value/1,
-         init_state/0, gen_field/0, generate/0, size/1]).
+-export([gen_op/0, gen_field/0, generate/0, size/1]).
 -endif.
 
 -export_type([map/0, binary_map/0, map_op/0]).
 
 -type binary_map() :: binary(). %% A binary that from_binary/1 will accept
 -type map() :: {riak_dt_vclock:vclock(), entries(), deferred()}.
--type entries() :: ordsets:ordset(entry()).
--type entry() :: {field_tag(), CRDT :: crdt()}.
--type field_tag() :: {Field :: field(), Tag :: riak_dt:dot()}.
+-type entries() :: [{field(), {[{riak_dt:dot(), crdt()}],
+                               TS::riak_dt_vclock:vclock()}}]. %% Store a Tombstone clock, GLB?
 -type field() :: {Name :: binary(), CRDTModule :: crdt_mod()}.
+
 %% Only field removals can be deferred. CRDTs stored in the map may
-%% have contexts and deferred operatiosn, but as these are part of the
+%% have contexts and deferred operations, but as these are part of the
 %% state, they are stored under the field as an update like any other.
 -type deferred() :: [{context(), [field()]}].
 
--type crdt_mod() :: riak_dt_pncounter | riak_dt_lwwreg |
+-type crdt_mod() :: riak_dt_emcntr | riak_dt_lwwreg |
                     riak_dt_od_flag |
                     riak_dt_map | riak_dt_orswot.
 
--type crdt()  ::  riak_dt_pncounter:pncounter() | riak_dt_od_flag:od_flag() |
+-type crdt()  ::  riak_dt_emcntr:emcntr() | riak_dt_od_flag:od_flag() |
                   riak_dt_lwwreg:lwwreg() |
                   riak_dt_orswot:orswot() |
                   riak_dt_map:map().
 
 -type map_op() :: {update, [map_field_update() | map_field_op()]}.
 
--type map_field_op() :: {add, field()} | {remove, field()}.
+-type map_field_op() ::  {remove, field()}.
 -type map_field_update() :: {update, field(), crdt_op()}.
 
--type crdt_op() :: riak_dt_pncounter:pncounter_op() |
+-type crdt_op() :: riak_dt_emcntr:emcntr_op() |
                    riak_dt_lwwreg:lwwreg_op() |
                    riak_dt_orswot:orswot_op() | riak_dt_od_flag:od_flag_op() |
                    riak_dt_map:map_op().
@@ -115,7 +114,7 @@
 %% @doc Create a new, empty Map.
 -spec new() -> map().
 new() ->
-    {riak_dt_vclock:fresh(), ordsets:new(), orddict:new()}.
+    {riak_dt_vclock:fresh(), orddict:new(), orddict:new()}.
 
 %% @doc sets the clock in the map to that `Clock'. Used by a
 %% containing Map for sub-CRDTs
@@ -126,14 +125,27 @@ parent_clock(Clock, {_MapClock, Values, Deferred}) ->
 %% @doc get the current set of values for this Map
 -spec value(map()) -> values().
 value({_Clock, Values, _Deferred}) ->
-    Res = lists:foldl(fun({{{_Name, Type}=Key, _Dot}, Value}, Acc) ->
-                              %% if key is in Acc merge with it and replace
-                              dict:update(Key, fun(V) ->
-                                                       Type:merge(V, Value) end,
-                                          Value, Acc) end,
-                      dict:new(),
-                      Values),
-    [{K, Type:value(V)} || {{_Name, Type}=K, V} <- dict:to_list(Res)].
+    orddict:fold(fun({Name, Type}, CRDTs, Acc) ->
+                         Merged = merge_crdts(Type, CRDTs),
+                         [{{Name, Type}, Type:value(Merged)} | Acc] end,
+                 [],
+                 Values).
+
+%% @private merge entry for field, if present, or return new if not
+merge_field({_Name, Type}, error) ->
+    Type:new();
+merge_field({_Name, Type}, {ok, CRDTs}) ->
+    merge_crdts(Type, CRDTs);
+merge_field(Field, Values) ->
+    merge_field(Field, orddict:find(Field, Values)).
+
+%% @private merge the CRDTs of a type
+merge_crdts(Type, {CRDTs, TS}) ->
+    V = orddict:fold(fun(_Dot, CRDT, CRDT0) ->
+                             Type:merge(CRDT0, CRDT) end,
+                     Type:new(),
+                     CRDTs),
+    Type:merge(TS, V).
 
 %% @doc query map (not implemented yet)
 -spec value(term(), map()) -> values().
@@ -150,24 +162,23 @@ value(_, Map) ->
 %% and the result inserted otherwise, the operation is applied to the
 %% local value.
 %%
-%% {add, `field()'}' where field is `{name, type}' results in `field'
-%% being added to the Map, and a new crdt of `type' being its value.
-%% `{remove, `field()'}' where field is `{name, type}', results in the
-%% crdt at `field' and the key and value being removed. A concurrent
-%% `update' | `add' will win over a remove.
+%%  `{remove, `field()'}' where field is `{name, type}', results in
+%%  the crdt at `field' and the key and value being removed. A
+%%  concurrent `update' will "win" over a remove so that the field is
+%%  still present, and it's value will contain the concurrent update.
 %%
-%% Either all of `Ops' are performed successfully, or none are.
-%%
-%% @see riak_dt_orswot for more details.
+%% Atomic, all of `Ops' are performed successfully, or none are.
 -spec update(map_op(), riak_dt:actor() | riak_dt:dot(), map()) ->
                     {ok, map()} | precondition_error().
 update(Op, ActorOrDot, Map) ->
     update(Op, ActorOrDot, Map, undefined).
 
 %% @doc the same as `update/3' except that the context ensures no
-%% unseen field adds are removed, and removal of unseen adds is
-%% deferred. The Context is passed on as the context for any nested
-%% types.
+%% unseen field updates are removed, and removal of unseen updates is
+%% deferred. The Context is passed down as the context for any nested
+%% types. hence the common clock.
+%%
+%% @see parent_clock/2
 -spec update(map_op(), riak_dt:actor() | riak_dt:dot(), map(), riak_dt:context()) ->
                     {ok, map()}.
 update({update, Ops}, ActorOrDot, {Clock0, Values, Deferred}, Ctx) ->
@@ -194,22 +205,13 @@ update_clock(Actor, Clock) ->
 apply_ops([], _Dot, Map, _Ctx) ->
     {ok, Map};
 apply_ops([{update, {_Name, Type}=Field, Op} | Rest], Dot, {Clock, Values, Deferred}, Ctx) ->
-    {CRDT, TrimmedValues} = ordsets:fold(fun({{F, _D}, Value}=E, {Acc, ValuesAcc}) when F == Field ->
-                                                 %% remove the tagged
-                                                 %% value, as it will
-                                                 %% be superseded by
-                                                 %% the new update
-                                                 {Type:merge(Acc, Value),
-                                                  ordsets:del_element(E, ValuesAcc)};
-                                            (_E, Acc) ->
-                                                 Acc
-                                         end,
-                                         {Type:new(), Values},
-                                         Values),
+    CRDT = merge_field(Field, Values),
     CRDT1 = Type:parent_clock(Clock, CRDT),
     case Type:update(Op, Dot, CRDT1, Ctx) of
         {ok, Updated} ->
-            NewValues = ordsets:add_element({{Field, Dot}, Updated}, TrimmedValues),
+            NewValues = orddict:store(Field, {orddict:store(Dot, Updated, orddict:new()),
+                                              Type:new()} %% Tombstone is merge now @TODO IS THAT CORRECT??
+                                     , Values),
             apply_ops(Rest, Dot, {Clock, NewValues, Deferred}, Ctx);
         Error ->
             Error
@@ -220,16 +222,7 @@ apply_ops([{remove, Field} | Rest], Dot, Map, Ctx) ->
             apply_ops(Rest, Dot, NewMap, Ctx);
         E ->
             E
-    end;
-apply_ops([{add, {_Name, Mod}=Field} | Rest], Dot, {Clock, Values, Deferred}, Ctx) ->
-    %% @TODO ¿Should an add read and replace, or stand alone? If it
-    %% stands alone, a concurrent remove results in an empty field,
-    %% which is nice. After an update though, we're back to a mixed,
-    %% unknown result. And of course we have a duplicate entry. Adds
-    %% are weird.
-    ToAdd = {{Field, Dot}, Mod:new()},
-    NewValues = ordsets:add_element(ToAdd, Values),
-    apply_ops(Rest, Dot, {Clock, NewValues, Deferred}, Ctx).
+    end.
 
 %% @private when context is undefined, we simply remove all instances
 %% of Field, regardless of their dot. If the field is not present then
@@ -246,48 +239,85 @@ apply_ops([{add, {_Name, Mod}=Field} | Rest], Dot, {Clock, Values, Deferred}, Ct
 -spec remove_field(field(), map(), context()) ->
                           {ok, map()} | precondition_error().
 remove_field(Field, {Clock, Values, Deferred}, undefined) ->
-    {Removed, NewValues} = ordsets:fold(fun({{F, _Dot}, _Val}, {_B, AccIn}) when F == Field ->
-                                                {true, AccIn};
-                                           (Elem, {B, AccIn}) ->
-                                                {B, ordsets:add_element(Elem, AccIn)}
-                                        end,
-                                        {false, ordsets:new()},
-                                        Values),
-    case Removed of
-        false ->
+    case orddict:find(Field, Values) of
+        error ->
             {error, {precondition, {not_present, Field}}};
-        _ ->
-            {ok, {Clock, NewValues, Deferred}}
+        {ok, _Removed} ->
+            {ok, {Clock, orddict:erase(Field, Values), Deferred}}
     end;
 %% Context removes
 remove_field(Field, {Clock, Values, Deferred0}, Ctx) ->
     Deferred = defer_remove(Clock, Ctx, Field, Deferred0),
-    NewValues = ordsets:fold(fun({{F, Dot}, _Val}=E, AccIn) when F == Field ->
-                                     keep_or_drop(Ctx, Dot, AccIn, E);
-                                (Elem, AccIn) ->
-                                     ordsets:add_element(Elem, AccIn)
-                             end,
-                             ordsets:new(),
-                             Values),
+    NewValues = case ctx_rem_field(Field, Values, Ctx, Clock) of
+                    empty ->
+                        orddict:erase(Field, Values);
+                    CRDTs ->
+                        orddict:store(Field, CRDTs, Values)
+                end,
     {ok, {Clock, NewValues, Deferred}}.
 
+%% @private drop dominated fields
+ctx_rem_field(_Field, error, _Ctx_, _Clock) ->
+    empty;
+ctx_rem_field({_, Type}, {ok, {CRDTs, TS0}}, Ctx, MapClock) ->
+    %% Create a tombstone CRDT to merge with any dots that survive.
+    %% If the context is removing a field at dot {a, 1} and the
+    %% current field is {a, 2}, it needs to learn that all events from
+    %% {a, 1} are removed. If the ctx remove is at {a, 3} and the
+    %% current field is at {a, 2} then we need to remove all events
+    %% upto {a, 2}. The glb clock enables that.
+    %%
+    %% @TODO this doesn't really work for counters.
+    TombstoneClock = riak_dt_vclock:glb(Ctx, MapClock), %% GLB is events seen by both clocks only
+    TS = Type:parent_clock(TombstoneClock, Type:new()),
+    Remaining = orddict:fold(fun(Dot, CRDT, Keep) ->
+                                   case riak_dt_vclock:descends(Ctx, [Dot]) of
+                                       %% Ctx dominates the dot, don't
+                                       %% keep the field
+                                       true ->
+                                           Keep;
+                                       false ->
+                                           %% Dot concurrent with Ctx,
+                                           %% but still remove Ctx
+                                           %% values from field
+                                           %% @TODO or do we store this GLB??
+                                           %% CRDT2 = Type:merge(CRDT, TS),
+                                           orddict:store(Dot, CRDT, Keep)
+                                   end
+                           end,
+                           orddict:new(),
+                           CRDTs),
+    case orddict:size(Remaining) of
+        0 -> %% Ctx remove removed all dots for field
+            empty;
+        _ -> {Remaining, Type:merge(TS, TS0)}
+    end;
+ctx_rem_field(Field, Values, Ctx, MapClock) ->
+    ctx_rem_field(Field, orddict:find(Field, Values), Ctx, MapClock).
+
 %% @private If we're asked to remove something we don't have (or have,
-%% but maybe not having seen all 'adds' for it), is it because we've
-%% not seen the add|update that we've been asked to remove, or is it
-%% because we already removed it? In the former case, we can "defer"
-%% this operation by storing it, with its context, for later
-%% execution. If the clock for the Map descends the operation clock,
-%% then we don't need to defer the op, its already been done. It is
-%% _very_ important to note, that only _actorless_ operations can be
-%% saved. That is operations that DO NOT increment the clock. In Map
-%% this means field removals. Contexts for update operations do not
-%% result in deferred operations on the parent Map.
+%% but maybe not all 'updates' for it), is it because we've not seen
+%% the some update that we've been asked to remove, or is it because
+%% we already removed it? In the former case, we can "defer" this
+%% operation by storing it, with its context, for later execution. If
+%% the clock for the Map descends the operation clock, then we don't
+%% need to defer the op, its already been done. It is _very_ important
+%% to note, that only _actorless_ operations can be saved. That is
+%% operations that DO NOT need to increment the clock. In a Map this
+%% means field removals only. Contexts for update operations do not
+%% result in deferred operations on the parent Map. This simulates
+%% causal delivery, in that an `update' must be seen before it can be
+%% `removed'.
 -spec defer_remove(riak_dt_vclock:vclock(), riak_dt_vclock:vclock(), field(), deferred()) ->
                           deferred().
 defer_remove(Clock, Ctx, Field, Deferred) ->
     case riak_dt_vclock:descends(Clock, Ctx) of
         %% no need to save this remove, we're done
         true -> Deferred;
+        %% @TODO is there anything to be done with regard to
+        %% reset-remove semantic? Or is the GLB merge in
+        %% ctx_remove_field enough?
+        %% @TODO be more effecient, storeing [{a, 1}] -> F and [{a, 2}] -> F is wasteful, can we just merge contexts for a field?
         false -> orddict:update(Ctx,
                                 fun(Fields) ->
                                         ordsets:add_element(Field, Fields) end,
@@ -295,16 +325,117 @@ defer_remove(Clock, Ctx, Field, Deferred) ->
                                 Deferred)
     end.
 
-%% @doc merge two `map()'s.  and then a pairwise merge on all values
-%% in the value list.  This is the LUB function.
+%% @doc merge two `map()'s.
 -spec merge(map(), map()) -> map().
 merge({LHSClock, LHSEntries, LHSDeferred}, {RHSClock, RHSEntries, RHSDeferred}) ->
     Clock = riak_dt_vclock:merge([LHSClock, RHSClock]),
-    {Entries0, RHSUnique} = merge_left(LHSEntries, RHSEntries, RHSClock),
-    Entries1 = merge_right(LHSClock, RHSUnique),
-    Entries2 = ordsets:union(Entries0, Entries1),
-    Deferred = merge_deferred(LHSDeferred, RHSDeferred),
-    apply_deferred(Clock, Entries2, Deferred).
+    GLBClock = riak_dt_vclock:glb(LHSClock, RHSClock),
+    {CommonKeys, LHSUnique, RHSUnique} = key_sets(LHSEntries, RHSEntries),
+    Acc0 = merge_unique(LHSUnique, LHSEntries, RHSClock, GLBClock, orddict:new()),
+    Acc1 = merge_unique(RHSUnique, RHSEntries, LHSClock, GLBClock, Acc0),
+    Entries = merge_common(CommonKeys, LHSEntries, RHSEntries, LHSClock, RHSClock, GLBClock, Acc1),
+    Deferred = merge_deferred(RHSDeferred, LHSDeferred),
+    apply_deferred(Clock, Entries, Deferred).
+
+merge_unique(FieldSet, Entries, Clock, _GLBClock, Acc) ->
+    sets:fold(fun({_Name, Type}=Field, Keep) ->
+                      {Dots, TS} = orddict:fetch(Field, Entries),
+                      KeepDots = orddict:fold(fun(Dot, CRDT, ToKeep) ->
+                                                      case riak_dt_vclock:descends(Clock, [Dot]) of
+                                                          true ->
+                                                              %% Removed by otherside
+                                                              ToKeep;
+                                                          false ->
+                                                              %% %% Not removed this, but maybe some predecessor,
+                                                              %% %% remove any dot that the RHS has seen
+                                                              %% TS = Type:parent_clock(GLBClock, Type:new()),
+                                                              %% Trimmed = Type:merge(CRDT, TS),
+                                                              orddict:store(Dot, CRDT, ToKeep)
+                                                      end
+                                              end,
+                                              orddict:new(),
+                                              Dots),
+                      case orddict:size(KeepDots) of
+                          0 ->
+                              Keep;
+                          _ ->
+                              orddict:store(Field, {KeepDots, Type:merge(TS, Type:parent_clock(Clock, Type:new()))}, Keep)
+                      end
+              end,
+              Acc,
+              FieldSet).
+
+key_set(Orddict) ->
+    sets:from_list(orddict:fetch_keys(Orddict)).
+
+key_sets(LHS, RHS) ->
+    LHSet = key_set(LHS),
+    RHSet = key_set(RHS),
+    {sets:intersection(LHSet, RHSet),
+     sets:subtract(LHSet, RHSet),
+     sets:subtract(RHSet, LHSet)}.
+
+
+merge_side(Type, Fields, Dots, Clock) ->
+    sets:fold(fun(Dot, {Survivors, TS}) ->
+                      CRDT = orddict:fetch(Dot, Dots),
+                      case riak_dt_vclock:descends(Clock, [Dot]) of
+                          true ->
+                              {Survivors, Type:merge(CRDT, TS)};
+                          false ->
+                              {orddict:store(Dot, orddict:fetch(Dot, Dots), Survivors), TS}
+                      end
+              end,
+              {orddict:new(), Type:new()},
+              Fields).
+
+merge_common(FieldSet, LHS, RHS, LHSClock , RHSClock, _GLBClock, Acc) ->
+    sets:fold(fun({_, Type}=Field, Keep) ->
+                      {LHSDots, LHTS} = orddict:fetch(Field, LHS),
+                      {RHSDots, RHTS} = orddict:fetch(Field, RHS),
+                      {CommonDots, LHSUniqe, RHSUnique} = key_sets(LHSDots, RHSDots),
+                      TS = Type:merge(RHTS, LHTS),
+
+                      Acc0 = sets:fold(fun(Dot, Common) ->
+                                               L = orddict:fetch(Dot, LHSDots),
+                                               R = orddict:fetch(Dot, RHSDots),
+                                               orddict:store(Dot, Type:merge(L, R), Common)
+                                       end,
+                                       orddict:new(),
+                                       CommonDots),
+
+                      {LHSSurviving, _} = merge_side(Type, LHSUniqe, LHSDots, RHSClock),
+                      {RHSSurviving, _} = merge_side(Type, RHSUnique, RHSDots, LHSClock),
+
+                      %% TS = Type:parent_clock(GLBClock, Type:new()),
+
+                      case {orddict:size(Acc0), orddict:size(LHSSurviving), orddict:size(RHSSurviving)} of
+                          %% {0, 0, 0} ->
+                          %%     Keep;
+                          %% {0, 0, _} ->
+                          %%     Dots = orddict:fold(fun(Dot, CRDT, Tombstoned) ->
+                          %%                                 orddict:store(Dot, Type:merge(TS, CRDT), Tombstoned) end,
+                          %%                         orddict:new(),
+                          %%                         RHSSurviving),
+                          %%     orddict:store(Field, Dots, Keep);
+                          %% {0, _, 0} ->
+                          %%     Dots = orddict:fold(fun(Dot, CRDT, Tombstoned) ->
+                          %%                                 orddict:store(Dot, Type:merge(TS, CRDT), Tombstoned) end,
+                          %%                         orddict:new(),
+                          %%                         LHSSurviving),
+                          %%     orddict:store(Field, Dots, Keep);
+                          {_, _, _} ->
+                              Dots = orddict:from_list(lists:merge([Acc0, LHSSurviving, RHSSurviving])),
+                              case Dots of
+                                  [] ->
+                                      Keep;
+                                  _ ->
+                                      orddict:store(Field, {Dots, TS}, Keep)
+                              end
+                      end
+              end,
+              Acc,
+              FieldSet).
 
 %% @private
 -spec merge_deferred(deferred(), deferred()) -> deferred().
@@ -312,48 +443,6 @@ merge_deferred(LHS, RHS) ->
     orddict:merge(fun(_K, LH, RH) ->
                           ordsets:union(LH, RH) end,
                   LHS, RHS).
-
-%% @private Merge the common entries, returns the merged common and
-%% those unique to the right hand side.
--spec merge_left(entries(), entries(), riak_dt_vclock:vclock()) ->
-                        {entries(), entries()}.
-merge_left(LHSEntries, RHSEntries, RHSClock) ->
-    lists:foldl(fun({{_F, Dot}=Key, _CRDT}=E, {Acc, RHS}) ->
-                        case lists:keytake(Key, 1, RHS) of
-                            {value, E, RHS1} ->
-                                %% same in bolth
-                                {ordsets:add_element(E, Acc), RHS1};
-                            false ->
-                                %% RHS does not have this field/dot, should be dropped, or kept?
-                                Acc2 = keep_or_drop(RHSClock, Dot, Acc, E),
-                                {Acc2, RHS}
-                        end
-                end,
-                {ordsets:new(), RHSEntries},
-                LHSEntries).
-
-%% @private merge those elements that were unique to the right hand
-%% side. Returns the subset of entries that should be kept.
--spec merge_right(riak_dt_vclock:vclock(), entries()) -> entries().
-merge_right(LHSClock, RHSUnique) ->
-    lists:foldl(fun({{_F, Dot}, _CRDT}=E, Acc) ->
-                        keep_or_drop(LHSClock, Dot, Acc, E)
-                end,
-                ordsets:new(),
-                RHSUnique).
-
-%% @private decide (using `Clock') if the `Field' with `Tag' gets into
-%% `Entries' or not.
--spec keep_or_drop(riak_dt_vclock:vclock(), riak_dt:dot(), entries(), entry()) ->
-                          entries().
-keep_or_drop(Clock, Tag, Entries, Field) ->
-    case riak_dt_vclock:descends(Clock, [Tag]) of
-        true ->
-            Entries;
-        false ->
-            ordsets:add_element(Field, Entries)
-    end.
-
 
 %% @private apply those deferred field removals, if they're
 %% preconditions have been met, that is.
@@ -384,18 +473,16 @@ remove_all(Fields, Map, Ctx) ->
 equal({Clock1, Values1, Deferred1}, {Clock2, Values2, Deferred2}) ->
     riak_dt_vclock:equal(Clock1, Clock2) andalso
         Deferred1 == Deferred2 andalso
-        pairwise_equals(ordsets:to_list(Values1), ordsets:to_list(Values2)).
+        pairwise_equals(Values1, Values2).
 
-%% @Private Note, only called when we know that 2 sets of fields are
-%% equal. Both dicts therefore have the same set of keys.
 -spec pairwise_equals(entries(), entries()) -> boolean().
 pairwise_equals([], []) ->
     true;
-pairwise_equals([{{{Name, Type}, Dot}, CRDT1}| Rest1], [{{{Name, Type}, Dot}, CRDT2}|Rest2]) ->
-    case Type:equal(CRDT1, CRDT2) of
-        true ->
+pairwise_equals([{{Name, Type}, {Dots1, TS1}}| Rest1], [{{Name, Type}, {Dots2, TS2}}|Rest2]) ->
+    case {orddict:fetch_keys(Dots1) == orddict:fetch_keys(Dots2), Type:equal(TS1, TS2)} of
+        {true, true} ->
             pairwise_equals(Rest1, Rest2);
-        false ->
+        _ ->
             false
     end;
 pairwise_equals(_, _) ->
@@ -428,11 +515,12 @@ stat(field_count, {_, Fields, _}) ->
     length(Fields);
 stat(duplication, {_, Fields, _}) ->
     %% Number of duplicated fields
-    DeDuped = ordsets:fold(fun({{Field, _}, _}, Acc) ->
-                          ordsets:add_element(Field, Acc) end,
-                  ordsets:new(),
-                  Fields),
-    length(Fields) - length(DeDuped);
+    {FieldCnt, Duplicates} = orddict:fold(fun(_Field, {Dots ,_}, {FCnt, DCnt}) ->
+                                                  {FCnt+1, DCnt + orddict:size(Dots)}
+                                          end,
+                                          {0, 0},
+                                          Fields),
+    Duplicates - FieldCnt;
 stat(deferred_length, {_, _, Deferred}) ->
     length(Deferred);
 stat(_,_) -> undefined.
@@ -503,19 +591,20 @@ remfield_test() ->
 %% Bug found by EQC, not dropping dots in merge when an element is
 %% present in both Maos leads to removed items remaining after merge.
 present_but_removed_test() ->
+    F = {'X', riak_dt_lwwreg},
     %% Add Z to A
-    {ok, A} = update({update, [{add, {'Z', riak_dt_lwwreg}}]}, a, new()),
+    {ok, A} = update({update, [{update, F, {assign, <<"A">>}}]}, a, new()),
     %% Replicate it to C so A has 'Z'->{a, 1}
     C = A,
     %% Remove Z from A
-    {ok, A2} = update({update, [{remove, {'Z', riak_dt_lwwreg}}]}, a, A),
+    {ok, A2} = update({update, [{remove, F}]}, a, A),
     %% Add Z to B, a new replica
-    {ok, B} = update({update, [{add, {'Z', riak_dt_lwwreg}}]}, b, new()),
+    {ok, B} = update({update, [{update, F, {assign, <<"B">>}}]}, b, new()),
     %%  Replicate B to A, so now A has a Z, the one with a Dot of
     %%  {b,1} and clock of [{a, 1}, {b, 1}]
     A3 = merge(B, A2),
     %% Remove the 'Z' from B replica
-    {ok, B2} = update({update, [{remove, {'Z', riak_dt_lwwreg}}]}, b, B),
+    {ok, B2} = update({update, [{remove, F}]}, b, B),
     %% Both C and A have a 'Z', but when they merge, there should be
     %% no 'Z' as C's has been removed by A and A's has been removed by
     %% C.
@@ -533,14 +622,15 @@ present_but_removed_test() ->
 %% A bug EQC found where dropping the dots in merge was not enough if
 %% you then store the value with an empty clock (derp).
 no_dots_left_test() ->
-    {ok, A} =  update({update, [{add, {'Z', riak_dt_lwwreg}}]}, a, new()),
-    {ok, B} =  update({update, [{add, {'Z', riak_dt_lwwreg}}]}, b, new()),
+    F = {'Z', riak_dt_lwwreg},
+    {ok, A} =  update({update, [{update, F, {assign, <<"A">>}}]}, a, new()),
+    {ok, B} =  update({update, [{update, F, {assign, <<"B">>}}]}, b, new()),
     C = A, %% replicate A to empty C
-    {ok, A2} = update({update, [{remove, {'Z', riak_dt_lwwreg}}]}, a, A),
+    {ok, A2} = update({update, [{remove, F}]}, a, A),
     %% replicate B to A, now A has B's 'Z'
     A3 = merge(A2, B),
     %% Remove B's 'Z'
-    {ok, B2} = update({update, [{remove, {'Z', riak_dt_lwwreg}}]}, b, B),
+    {ok, B2} = update({update, [{remove, F}]}, b, B),
     %% Replicate C to B, now B has A's old 'Z'
     B3 = merge(B2, C),
     %% Merge everytyhing, without the fix You end up with 'Z' present,
@@ -551,15 +641,30 @@ no_dots_left_test() ->
                          [B3, C]),
     ?assertEqual([], value(Merged)).
 
+%% A reset-reove bug eqc found where dropping a superceded dot lost
+%% field remove merge information the dropped dot contained
+transitive_remove_test() ->
+    F = {'X', riak_dt_orswot},
+    A=B=new(),
+    {ok, A1} = update({update, [{update, F, {add, 0}}]}, a, A),
+    %% Replicate!
+    B1 = merge(A1, B),
+    {ok, A2} = update({update, [{remove, F}]}, a, A1),
+    {ok, B2} = update({update, [{update, F, {add, 1}}]}, b, B1),
+    %% Replicate
+    A3 = merge(A2, B2),
+    %% that remove of F from A means remove the 0 A added to F
+    ?assertEqual([{F, [1]}], value(A3)),
+    {ok, B3} = update({update, [{update, F, {add, 2}}]}, b, B2),
+    %% replicate to A
+    A4 = merge(A3, B3),
+    %% final values
+    Final = merge(A4, B3),
+    ?assertEqual([{F, [1,2]}], value(Final)).
+
 
 -ifdef(EQC).
 -define(NUMTESTS, 1000).
-
-bin_roundtrip_test_() ->
-    crdt_statem_eqc:run_binary_rt(?MODULE, ?NUMTESTS).
-
-eqc_value_test_() ->
-    crdt_statem_eqc:run(?MODULE, ?NUMTESTS).
 
 %% ===================================
 %% crdt_statem_eqc callbacks
@@ -589,7 +694,7 @@ gen_op() ->
 
 gen_update() ->
     ?LET(Field, gen_field(),
-         oneof([{add, Field}, {remove, Field},
+         oneof([{remove, Field},
                 {update, Field, gen_field_op(Field)}])).
 
 gen_field() ->
@@ -602,88 +707,6 @@ gen_field() ->
 gen_field_op({_Name, Type}) ->
     Type:gen_op().
 
-init_state() ->
-    {0, dict:new()}.
-
-update_expected(ID, {update, Ops}, State) ->
-    %% Ops are atomic, all pass or all fail
-    %% return original state if any op failed
-    update_all(ID, Ops, State);
-update_expected(ID, {merge, SourceID}, {Cnt, Dict}) ->
-    {FA, FR} = dict:fetch(ID, Dict),
-    {TA, TR} = dict:fetch(SourceID, Dict),
-    MA = sets:union(FA, TA),
-    MR = sets:union(FR, TR),
-    {Cnt, dict:store(ID, {MA, MR}, Dict)};
-update_expected(ID, create, {Cnt, Dict}) ->
-    {Cnt, dict:store(ID, {sets:new(), sets:new()}, Dict)}.
-
-eqc_state_value({_Cnt, Dict}) ->
-    {A, R} = dict:fold(fun(_K, {Add, Rem}, {AAcc, RAcc}) ->
-                               {sets:union(Add, AAcc), sets:union(Rem, RAcc)} end,
-                       {sets:new(), sets:new()},
-                       Dict),
-    Remaining = sets:subtract(A, R),
-    Res = lists:foldl(fun({{_Name, Type}=Key, Value, _X}, Acc) ->
-                        %% if key is in Acc merge with it and replace
-                        dict:update(Key, fun(V) ->
-                                                 Type:merge(V, Value) end,
-                                    Value, Acc) end,
-                dict:new(),
-                sets:to_list(Remaining)),
-    [{K, Type:value(V)} || {{_Name, Type}=K, V} <- dict:to_list(Res)].
-
-%% @private
-%% @doc Apply the list of update operations to the model
-update_all(ID, Ops, OriginalState) ->
-    update_all(ID, Ops, OriginalState, OriginalState).
-
-update_all(_ID, [], _OriginalState, NewState) ->
-    NewState;
-update_all(ID, [{update, {_Name, Type}=Key, Op} | Rest], OriginalState, {Cnt0, Dict}) ->
-    CurrentValue = get_for_key(Key, ID, Dict),
-    %% handle precondition errors any precondition error means the
-    %% state is not changed at all
-    case Type:update(Op, ID, CurrentValue) of
-        {ok, Updated} ->
-            Cnt = Cnt0+1,
-            ToAdd = {Key, Updated, Cnt},
-            {A, R} = dict:fetch(ID, Dict),
-            update_all(ID, Rest, OriginalState, {Cnt, dict:store(ID, {sets:add_element(ToAdd, A), R}, Dict)});
-        _Error ->
-            OriginalState
-    end;
-update_all(ID, [{remove, Field} | Rest], OriginalState, {Cnt, Dict}) ->
-    {A, R} = dict:fetch(ID, Dict),
-    In = sets:subtract(A, R),
-    PresentFields = [E ||  {E, _, _X} <- sets:to_list(In)],
-    case lists:member(Field, PresentFields) of
-        true ->
-            ToRem = [{E, V, X} || {E, V, X} <- sets:to_list(A), E == Field],
-            NewState2 = {Cnt, dict:store(ID, {A, sets:union(R, sets:from_list(ToRem))}, Dict)},
-            update_all(ID, Rest, OriginalState, NewState2);
-        false ->
-            OriginalState
-    end;
-update_all(ID, [{add, {_Name, Type}=Field} | Rest], OriginalState, {Cnt0, Dict}) ->
-    Cnt = Cnt0+1,
-    ToAdd = {Field, Type:new(), Cnt},
-    {A, R} = dict:fetch(ID, Dict),
-    NewState = {Cnt, dict:store(ID, {sets:add_element(ToAdd, A), R}, Dict)},
-    update_all(ID, Rest, OriginalState, NewState).
-
-
-get_for_key({_N, T}=K, ID, Dict) ->
-    {A, R} = dict:fetch(ID, Dict),
-    Remaining = sets:subtract(A, R),
-    Res = lists:foldl(fun({{_Name, Type}=Key, Value, _X}, Acc) ->
-                        %% if key is in Acc merge with it and replace
-                        dict:update(Key, fun(V) ->
-                                                 Type:merge(V, Value) end,
-                                    Value, Acc) end,
-                dict:new(),
-                sets:to_list(Remaining)),
-    proplists:get_value(K, dict:to_list(Res), T:new()).
 
 -endif.
 
@@ -700,28 +723,35 @@ get_for_key({_N, T}=K, ID, Dict) ->
 %% `merge_left/3', but passes with the current structure, of
 %% `{field(), dot()}' as key.
 dot_key_test() ->
-    {ok, A} = update({update, [{add, {'X', riak_dt_orswot}}, {add, {'X', riak_dt_od_flag}}]}, a, new()),
+    {ok, A} = update({update, [{update, {'X', riak_dt_orswot}, {add, <<"a">>}}, {update, {'X', riak_dt_od_flag}, enable}]}, a, new()),
     B = A,
     {ok, A2} = update({update, [{remove, {'X', riak_dt_od_flag}}]}, a, A),
-    ?assertEqual([{{'X', riak_dt_orswot}, []}], value(merge(B, A2))).
+    ?assertEqual([{{'X', riak_dt_orswot}, [<<"a">>]}], value(merge(B, A2))).
 
 stat_test() ->
     Map = new(),
-    {ok, Map1} = update({update, [{add, {c, riak_dt_pncounter}},
-                                  {add, {s, riak_dt_orswot}},
-                                  {add, {m, riak_dt_map}},
-                                  {add, {l, riak_dt_lwwreg}},
-                                  {add, {l2, riak_dt_lwwreg}}]}, a1, Map),
-    {ok, Map2} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"foo">>, 1}}]}, a2, Map1),
-    {ok, Map3} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"bar">>, 2}}]}, a3, Map1),
+    {ok, Map1} = update({update, [{update, {c, riak_dt_emcntr}, increment},
+                                  {update, {s, riak_dt_orswot}, {add, <<"A">>}},
+                                  {update, {m, riak_dt_map}, {update, [{update, {ss, riak_dt_orswot}, {add, 0}}]}},
+                                  {update, {l, riak_dt_lwwreg}, {assign, <<"a">>, 1}},
+                                  {update, {l2, riak_dt_lwwreg}, {assign, <<"b">>, 2}}]}, a1, Map),
+    {ok, Map2} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"foo">>, 3}}]}, a2, Map1),
+    {ok, Map3} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"bar">>, 4}}]}, a3, Map1),
     Map4 = merge(Map2, Map3),
     ?assertEqual([{actor_count, 0}, {field_count, 0}, {duplication, 0}, {deferred_length, 0}], stats(Map)),
     ?assertEqual(3, stat(actor_count, Map4)),
-    ?assertEqual(6, stat(field_count, Map4)),
+    ?assertEqual(5, stat(field_count, Map4)),
     ?assertEqual(undefined, stat(waste_pct, Map4)),
     ?assertEqual(1, stat(duplication, Map4)),
-    {ok, Map5} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"baz">>, 2}}]}, a3, Map4),
-    ?assertEqual(5, stat(field_count, Map5)),
-    ?assertEqual(0, stat(duplication, Map5)).
+    {ok, Map5} = update({update, [{update, {l3, riak_dt_lwwreg}, {assign, <<"baz">>, 5}}]}, a3, Map4),
+    ?assertEqual(6, stat(field_count, Map5)),
+    ?assertEqual(1, stat(duplication, Map5)),
+    %% Updating field {l, riak_dt_lwwreg} merges the duplicates to a single field
+    %% @see apply_ops
+    {ok, Map6} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"bim">>, 6}}]}, a2, Map5),
+    ?assertEqual(0, stat(duplication, Map6)),
+    {ok, Map7} = update({update, [{remove, {l, riak_dt_lwwreg}}]}, a1, Map6),
+    ?assertEqual(5, stat(field_count, Map7)).
+
 
 -endif.

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -84,7 +84,7 @@
 
 %% EQC API
 -ifdef(EQC).
--export([gen_op/0, gen_field/0, generate/0, size/1]).
+-export([gen_op/0, gen_op/1, gen_field/0, gen_field/1,  generate/0, size/1]).
 -endif.
 
 -export_type([map/0, binary_map/0, map_op/0]).
@@ -765,23 +765,32 @@ generate() ->
                      new(),
                      Ops)).
 
+%% Add depth parameter
 gen_op() ->
-    ?LET(Ops, non_empty(list(gen_update())), {update, Ops}).
+    ?SIZED(Size, gen_op(Size)).
 
-gen_update() ->
-    ?LET(Field, gen_field(),
+gen_op(Size) ->
+    ?LET(Ops, non_empty(list(gen_update(Size))), {update, Ops}).
+
+gen_update(Size) ->
+    ?LET(Field, gen_field(Size),
          oneof([{remove, Field},
-                {update, Field, gen_field_op(Field)}])).
+                {update, Field, gen_field_op(Field, Size div 2)}])).
 
 gen_field() ->
-    {non_empty(binary()), oneof([riak_dt_pncounter,
-                                 riak_dt_orswot,
-                                 riak_dt_lwwreg,
-                                 riak_dt_map,
-                                 riak_dt_od_flag])}.
+    ?SIZED(Size, gen_field(Size)).
 
-gen_field_op({_Name, Type}) ->
-    Type:gen_op().
+gen_field(Size) ->
+    {growingelements(['A', 'B', 'C', 'X', 'Y', 'Z']) %% Macro? Bigger?
+    , elements([
+                riak_dt_emcntr,
+                riak_dt_orswot,
+                riak_dt_lwwreg,
+                riak_dt_od_flag
+               ] ++ [riak_dt_map || Size > 0])}.
+
+gen_field_op({_Name, Type}, Size) ->
+    Type:gen_op(Size).
 
 
 -endif.

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -24,22 +24,36 @@
 %% same tombstone-less, Observed Remove semantics as `riak_dt_orswot'.
 %% A Map is set of `Field's a `Field' is a two-tuple of:
 %% `{Name::binary(), CRDTModule::module()}' where the second element
-%% is the name of a crdt module that conforms to the `riak_dt'
-%% behaviour. CRDTs stored inside the Map will have their `update/3'
-%% function called, but the second argument will be a `riak_dt:dot()',
-%% so that they share the causal context of the map, even when fields
-%% are removed, and subsequently re-added.
+%% is the name of a crdt module that may be embedded. CRDTs stored
+%% inside the Map will have their `update/3' function called, but the
+%% second argument will be a `riak_dt:dot()', so that they share the
+%% causal context of the map, even when fields are removed, and
+%% subsequently re-added.
 %%
-%% The contents of the Map are modelled as a set of `{field(),
-%% value(), dot()}' tuples, where `dot()' is the last event that
-%% occurred on the field. When merging fields of the same name, but
-%% different `dot' are _not_ merged. On updating a field, all the
-%% elements in the set for that field are merged, updated, and
-%% replaced with a new `dot' for the update event. This means that in
-%% a divergent Map with many concurrent updates, a merged map will
-%% have duplicate entries for any updated fields until an update event
-%% occurs for that field, unifying the divergent field into a single
-%% field.
+%% The contents of the Map are modelled as a dictionary of
+%% `field_name()' to `field_value()' mappings. Where `field_ name()'
+%% is a two tuple of an opaque `binary()' name, and one of the
+%% embeddable crdt types (currently `riak_dt_orswot',
+%% `riak_dt_emcntr', `riak_dt_lwwreg', `riak_dt_od_flag', and
+%% `riak_dt_map'). The reason for this limitation is that embedded
+%% types must support embedding: that is a shared, `dot'-based, causal
+%% context, and a reset-remove semantic (more on these below.)  The
+%% `field_value()' is a two-tuple of `entries()' and a
+%% `tombstone()'. The presence of a `tombstone()' in a "tombstoneless"
+%% Map is confusing. The `tombstone()' is only stored for fields that
+%% are currently in the map, removing a field also removes its
+%% tombstone.
+%%
+%%  <<-- New docs @TODO update the docs to reflect the -----%% >> old
+%% docs current impl better (and describe the semantic fully!)
+%%
+%% merging fields of the same name, but different `dot' are _not_
+%% merged. On updating a field, all the elements in the set for that
+%% field are merged, updated, and replaced with a new `dot' for the
+%% update event. This means that in a divergent Map with many
+%% concurrent updates, a merged map will have duplicate entries for
+%% any updated fields until an update event occurs for that field,
+%% unifying the divergent field into a single field.
 %%
 %% Attempting to remove a `field' that is not present in the map will
 %% lead to a precondition error. An operation on a field value that
@@ -77,15 +91,24 @@
 
 -type binary_map() :: binary(). %% A binary that from_binary/1 will accept
 -type map() :: {riak_dt_vclock:vclock(), entries(), deferred()}.
--type entries() :: [{field(), {[{riak_dt:dot(), crdt()}],
-                               TS::riak_dt_vclock:vclock()}}]. %% Store a Tombstone clock, GLB?
--type field() :: {Name :: binary(), CRDTModule :: crdt_mod()}.
+-type entries() :: [field()].
+-type field() :: {field_name(), field_value()}.
+-type field_name() :: {Name :: binary(), CRDTModule :: crdt_mod()}.
+-type field_value() :: {crdts(), tombstone()}.
+
+-type crdts() :: [entry()].
+-type entry() :: {riak_dt:dot(), crdt()}.
+
+%% Only for present fields, ensures removes propogate
+-type tombstone() :: crdt().
 
 %% Only field removals can be deferred. CRDTs stored in the map may
 %% have contexts and deferred operations, but as these are part of the
 %% state, they are stored under the field as an update like any other.
 -type deferred() :: [{context(), [field()]}].
 
+%% limited to only those mods that support both a shared causal
+%% context, and by extension, the reset-remove semantic.
 -type crdt_mod() :: riak_dt_emcntr | riak_dt_lwwreg |
                     riak_dt_od_flag |
                     riak_dt_map | riak_dt_orswot.
@@ -145,6 +168,7 @@ merge_crdts(Type, {CRDTs, TS}) ->
                              Type:merge(CRDT0, CRDT) end,
                      Type:new(),
                      CRDTs),
+    %% Merge with the tombstone to drop any removed dots
     Type:merge(TS, V).
 
 %% @doc query map (not implemented yet)
@@ -210,7 +234,11 @@ apply_ops([{update, {_Name, Type}=Field, Op} | Rest], Dot, {Clock, Values, Defer
     case Type:update(Op, Dot, CRDT1, Ctx) of
         {ok, Updated} ->
             NewValues = orddict:store(Field, {orddict:store(Dot, Updated, orddict:new()),
-                                              Type:new()} %% Tombstone is merge now @TODO IS THAT CORRECT??
+                                              %% old tombstone was
+                                              %% merged into current
+                                              %% value so create a new
+                                              %% empty one
+                                              Type:new()}
                                      , Values),
             apply_ops(Rest, Dot, {Clock, NewValues, Deferred}, Ctx);
         Error ->
@@ -260,37 +288,27 @@ remove_field(Field, {Clock, Values, Deferred0}, Ctx) ->
 ctx_rem_field(_Field, error, _Ctx_, _Clock) ->
     empty;
 ctx_rem_field({_, Type}, {ok, {CRDTs, TS0}}, Ctx, MapClock) ->
-    %% Create a tombstone CRDT to merge with any dots that survive.
-    %% If the context is removing a field at dot {a, 1} and the
-    %% current field is {a, 2}, it needs to learn that all events from
-    %% {a, 1} are removed. If the ctx remove is at {a, 3} and the
-    %% current field is at {a, 2} then we need to remove all events
-    %% upto {a, 2}. The glb clock enables that.
+    %% Drop dominated fields, and update the tombstone.
     %%
-    %% @TODO this doesn't really work for counters.
+    %% If the context is removing a field at dot {a, 1} and the
+    %% current field is {a, 2}, the tombstone ensures that all events
+    %% from {a, 1} are removed from the crdt value. If the ctx remove
+    %% is at {a, 3} and the current field is at {a, 2} then we need to
+    %% remove only events upto {a, 2}. The glb clock enables that.
+    %%
+    %% @TODO document how this doesn't really work for counters.
     TombstoneClock = riak_dt_vclock:glb(Ctx, MapClock), %% GLB is events seen by both clocks only
     TS = Type:parent_clock(TombstoneClock, Type:new()),
-    Remaining = orddict:fold(fun(Dot, CRDT, Keep) ->
-                                   case riak_dt_vclock:descends(Ctx, [Dot]) of
-                                       %% Ctx dominates the dot, don't
-                                       %% keep the field
-                                       true ->
-                                           Keep;
-                                       false ->
-                                           %% Dot concurrent with Ctx,
-                                           %% but still remove Ctx
-                                           %% values from field
-                                           %% @TODO or do we store this GLB??
-                                           %% CRDT2 = Type:merge(CRDT, TS),
-                                           orddict:store(Dot, CRDT, Keep)
-                                   end
-                           end,
-                           orddict:new(),
+    Remaining = orddict:filter(fun(Dot, _CRDT) ->
+                                       is_dot_unseen(Dot, Ctx)
+                               end,
                            CRDTs),
     case orddict:size(Remaining) of
         0 -> %% Ctx remove removed all dots for field
             empty;
-        _ -> {Remaining, Type:merge(TS, TS0)}
+        _ ->
+            %% Update the tombstone with the GLB clock
+            {Remaining, Type:merge(TS, TS0)}
     end;
 ctx_rem_field(Field, Values, Ctx, MapClock) ->
     ctx_rem_field(Field, orddict:find(Field, Values), Ctx, MapClock).
@@ -314,10 +332,6 @@ defer_remove(Clock, Ctx, Field, Deferred) ->
     case riak_dt_vclock:descends(Clock, Ctx) of
         %% no need to save this remove, we're done
         true -> Deferred;
-        %% @TODO is there anything to be done with regard to
-        %% reset-remove semantic? Or is the GLB merge in
-        %% ctx_remove_field enough?
-        %% @TODO be more effecient, storeing [{a, 1}] -> F and [{a, 2}] -> F is wasteful, can we just merge contexts for a field?
         false -> orddict:update(Ctx,
                                 fun(Fields) ->
                                         ordsets:add_element(Field, Fields) end,
@@ -327,47 +341,62 @@ defer_remove(Clock, Ctx, Field, Deferred) ->
 
 %% @doc merge two `map()'s.
 -spec merge(map(), map()) -> map().
+merge(Map, Map) ->
+    Map;
+%% @TODO is there a way to optimise this, based on clocks maybe?
 merge({LHSClock, LHSEntries, LHSDeferred}, {RHSClock, RHSEntries, RHSDeferred}) ->
     Clock = riak_dt_vclock:merge([LHSClock, RHSClock]),
-    GLBClock = riak_dt_vclock:glb(LHSClock, RHSClock),
     {CommonKeys, LHSUnique, RHSUnique} = key_sets(LHSEntries, RHSEntries),
-    Acc0 = merge_unique(LHSUnique, LHSEntries, RHSClock, GLBClock, orddict:new()),
-    Acc1 = merge_unique(RHSUnique, RHSEntries, LHSClock, GLBClock, Acc0),
-    Entries = merge_common(CommonKeys, LHSEntries, RHSEntries, LHSClock, RHSClock, GLBClock, Acc1),
+    Acc0 = filter_unique(LHSUnique, LHSEntries, RHSClock, orddict:new()),
+    Acc1 = filter_unique(RHSUnique, RHSEntries, LHSClock, Acc0),
+    Entries = merge_common(CommonKeys, LHSEntries, RHSEntries, LHSClock, RHSClock, Acc1),
     Deferred = merge_deferred(RHSDeferred, LHSDeferred),
     apply_deferred(Clock, Entries, Deferred).
 
-merge_unique(FieldSet, Entries, Clock, _GLBClock, Acc) ->
+%% @private filter the set of fields that are on one side of a merge
+%% only.
+-spec filter_unique(set(), entries(), riak_dt_vclock:vclock(), entries()) -> entries().
+filter_unique(FieldSet, Entries, Clock, Acc) ->
     sets:fold(fun({_Name, Type}=Field, Keep) ->
                       {Dots, TS} = orddict:fetch(Field, Entries),
-                      KeepDots = orddict:fold(fun(Dot, CRDT, ToKeep) ->
-                                                      case riak_dt_vclock:descends(Clock, [Dot]) of
-                                                          true ->
-                                                              %% Removed by otherside
-                                                              ToKeep;
-                                                          false ->
-                                                              %% %% Not removed this, but maybe some predecessor,
-                                                              %% %% remove any dot that the RHS has seen
-                                                              %% TS = Type:parent_clock(GLBClock, Type:new()),
-                                                              %% Trimmed = Type:merge(CRDT, TS),
-                                                              orddict:store(Dot, CRDT, ToKeep)
-                                                      end
+                      KeepDots = orddict:filter(fun(Dot, _CRDT) ->
+                                                      is_dot_unseen(Dot, Clock)
                                               end,
-                                              orddict:new(),
                                               Dots),
+
                       case orddict:size(KeepDots) of
                           0 ->
                               Keep;
                           _ ->
-                              orddict:store(Field, {KeepDots, Type:merge(TS, Type:parent_clock(Clock, Type:new()))}, Keep)
+                              %% create a tombstone since the
+                              %% otherside does not have this field,
+                              %% it either removed it, or never had
+                              %% it.  If it never had it, the removing
+                              %% dots in the tombstone will have no
+                              %% impact on the value, if the otherside
+                              %% removed it, then the removed dots
+                              %% will be propogated by the tombstone.
+                              Tombstone = Type:merge(TS, Type:parent_clock(Clock, Type:new())),
+                              orddict:store(Field, {KeepDots, Tombstone}, Keep)
                       end
               end,
               Acc,
               FieldSet).
 
+%% @private predicate function, `true' if the provided `dot()' is
+%% concurrent with the clock, `false' if the clock has seen the dot.
+-spec is_dot_unseen(riak_dt:dot(), riak_dt_vclock:vclock()) -> boolean().
+is_dot_unseen(Dot, Clock) ->
+    not riak_dt_vclock:descends(Clock, [Dot]).
+
+%% @doc Get the keys from an orddict as a set
+-spec key_set(orddict:orddict()) -> set().
 key_set(Orddict) ->
     sets:from_list(orddict:fetch_keys(Orddict)).
 
+%% @doc break the keys from an two orddicts out into three sets, the
+%% common keys, those unique to one, and those unique to the other.
+-spec key_sets(orddict:orddict(), orddict:orddict()) -> {set(), set(), set()}.
 key_sets(LHS, RHS) ->
     LHSet = key_set(LHS),
     RHSet = key_set(RHS),
@@ -376,63 +405,49 @@ key_sets(LHS, RHS) ->
      sets:subtract(RHSet, LHSet)}.
 
 
-merge_side(Type, Fields, Dots, Clock) ->
-    sets:fold(fun(Dot, {Survivors, TS}) ->
-                      CRDT = orddict:fetch(Dot, Dots),
-                      case riak_dt_vclock:descends(Clock, [Dot]) of
-                          true ->
-                              {Survivors, Type:merge(CRDT, TS)};
-                          false ->
-                              {orddict:store(Dot, orddict:fetch(Dot, Dots), Survivors), TS}
-                      end
-              end,
-              {orddict:new(), Type:new()},
-              Fields).
+%% @private for a set of dots (that are unique to one side) decide
+%% whether to keep, or drop each.
+-spec filter_dots(entries(), orddict:orddict(), riak_dt_vclock:vclock()) -> entries().
+filter_dots(Dots, CRDTs, Clock) ->
+    DotsToKeep = sets:filter(fun(Dot) ->
+                                     is_dot_unseen(Dot, Clock)
+                             end,
+                             Dots),
 
-merge_common(FieldSet, LHS, RHS, LHSClock , RHSClock, _GLBClock, Acc) ->
+    orddict:filter(fun(Dot, _CRDT) ->
+                           sets:is_element(Dot, DotsToKeep)
+                   end,
+                   CRDTs).
+
+%% @private merge the common fields into a set of surviving dots and a
+%% tombstone per field.  If a dot is on both sides, keep it. If it is
+%% only on one side, drop it if dominated by the otheride's clock.
+merge_common(FieldSet, LHS, RHS, LHSClock , RHSClock, Acc) ->
     sets:fold(fun({_, Type}=Field, Keep) ->
                       {LHSDots, LHTS} = orddict:fetch(Field, LHS),
                       {RHSDots, RHTS} = orddict:fetch(Field, RHS),
                       {CommonDots, LHSUniqe, RHSUnique} = key_sets(LHSDots, RHSDots),
                       TS = Type:merge(RHTS, LHTS),
 
-                      Acc0 = sets:fold(fun(Dot, Common) ->
-                                               L = orddict:fetch(Dot, LHSDots),
-                                               R = orddict:fetch(Dot, RHSDots),
-                                               orddict:store(Dot, Type:merge(L, R), Common)
-                                       end,
-                                       orddict:new(),
-                                       CommonDots),
+                      CommonSurviving = sets:fold(fun(Dot, Common) ->
+                                                          L = orddict:fetch(Dot, LHSDots),
+                                                          orddict:store(Dot, L, Common)
+                                                  end,
+                                                  orddict:new(),
+                                                  CommonDots),
 
-                      {LHSSurviving, _} = merge_side(Type, LHSUniqe, LHSDots, RHSClock),
-                      {RHSSurviving, _} = merge_side(Type, RHSUnique, RHSDots, LHSClock),
+                      LHSSurviving = filter_dots(LHSUniqe, LHSDots, RHSClock),
+                      RHSSurviving = filter_dots(RHSUnique, RHSDots, LHSClock),
 
-                      %% TS = Type:parent_clock(GLBClock, Type:new()),
+                      Dots = orddict:from_list(lists:merge([CommonSurviving, LHSSurviving, RHSSurviving])),
 
-                      case {orddict:size(Acc0), orddict:size(LHSSurviving), orddict:size(RHSSurviving)} of
-                          %% {0, 0, 0} ->
-                          %%     Keep;
-                          %% {0, 0, _} ->
-                          %%     Dots = orddict:fold(fun(Dot, CRDT, Tombstoned) ->
-                          %%                                 orddict:store(Dot, Type:merge(TS, CRDT), Tombstoned) end,
-                          %%                         orddict:new(),
-                          %%                         RHSSurviving),
-                          %%     orddict:store(Field, Dots, Keep);
-                          %% {0, _, 0} ->
-                          %%     Dots = orddict:fold(fun(Dot, CRDT, Tombstoned) ->
-                          %%                                 orddict:store(Dot, Type:merge(TS, CRDT), Tombstoned) end,
-                          %%                         orddict:new(),
-                          %%                         LHSSurviving),
-                          %%     orddict:store(Field, Dots, Keep);
-                          {_, _, _} ->
-                              Dots = orddict:from_list(lists:merge([Acc0, LHSSurviving, RHSSurviving])),
-                              case Dots of
-                                  [] ->
-                                      Keep;
-                                  _ ->
-                                      orddict:store(Field, {Dots, TS}, Keep)
-                              end
+                      case Dots of
+                          [] ->
+                              Keep;
+                          _ ->
+                              orddict:store(Field, {Dots, TS}, Keep)
                       end
+
               end,
               Acc,
               FieldSet).
@@ -641,9 +656,10 @@ no_dots_left_test() ->
                          [B3, C]),
     ?assertEqual([], value(Merged)).
 
-%% A reset-reove bug eqc found where dropping a superceded dot lost
-%% field remove merge information the dropped dot contained
-transitive_remove_test() ->
+%% A reset-remove bug eqc found where dropping a superseded dot lost
+%% field remove merge information the dropped dot contained, adding
+%% the tombstone fixed this.
+tombstone_remove_test() ->
     F = {'X', riak_dt_orswot},
     A=B=new(),
     {ok, A1} = update({update, [{update, F, {add, 0}}]}, a, A),
@@ -660,8 +676,59 @@ transitive_remove_test() ->
     A4 = merge(A3, B3),
     %% final values
     Final = merge(A4, B3),
+    %% before adding the tombstone, the dropped dots were simply
+    %% merged with the surviving field. When the second update to B
+    %% was merged with A, that information contained in the superseded
+    %% field in A at {b,1} was lost (since it was merged into the
+    %% _VALUE_). This casued the [0] from A's first dot to
+    %% resurface. By adding the tombstone, the superseded field merges
+    %% it's tombstone with the surviving {b, 2} field so the remove
+    %% information is preserved, even though the {b, 1} value is
+    %% dropped. Pro-tip, don't alter the CRDTs' values in the merge!
     ?assertEqual([{F, [1,2]}], value(Final)).
 
+%% This test is a regression test for a counter example found by eqc.
+%% The previous version of riak_dt_map used the `dot' from the field
+%% update/creation event as key in `merge_left/3'. Of course multiple
+%% fields can be added/updated at the same time. This means they get
+%% the same `dot'. When merging two replicas, it is possible that one
+%% has removed one or more of the fields added at a particular `dot',
+%% which meant a function clause error in `merge_left/3'. The
+%% structure was wrong, it didn't take into account the possibility
+%% that multiple fields could have the same `dot', when clearly, they
+%% can. This test fails with `dot' as the key for a field in
+%% `merge_left/3', but passes with the current structure, of
+%% `{field(), dot()}' as key.
+dot_key_test() ->
+    {ok, A} = update({update, [{update, {'X', riak_dt_orswot}, {add, <<"a">>}}, {update, {'X', riak_dt_od_flag}, enable}]}, a, new()),
+    B = A,
+    {ok, A2} = update({update, [{remove, {'X', riak_dt_od_flag}}]}, a, A),
+    ?assertEqual([{{'X', riak_dt_orswot}, [<<"a">>]}], value(merge(B, A2))).
+
+stat_test() ->
+    Map = new(),
+    {ok, Map1} = update({update, [{update, {c, riak_dt_emcntr}, increment},
+                                  {update, {s, riak_dt_orswot}, {add, <<"A">>}},
+                                  {update, {m, riak_dt_map}, {update, [{update, {ss, riak_dt_orswot}, {add, 0}}]}},
+                                  {update, {l, riak_dt_lwwreg}, {assign, <<"a">>, 1}},
+                                  {update, {l2, riak_dt_lwwreg}, {assign, <<"b">>, 2}}]}, a1, Map),
+    {ok, Map2} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"foo">>, 3}}]}, a2, Map1),
+    {ok, Map3} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"bar">>, 4}}]}, a3, Map1),
+    Map4 = merge(Map2, Map3),
+    ?assertEqual([{actor_count, 0}, {field_count, 0}, {duplication, 0}, {deferred_length, 0}], stats(Map)),
+    ?assertEqual(3, stat(actor_count, Map4)),
+    ?assertEqual(5, stat(field_count, Map4)),
+    ?assertEqual(undefined, stat(waste_pct, Map4)),
+    ?assertEqual(1, stat(duplication, Map4)),
+    {ok, Map5} = update({update, [{update, {l3, riak_dt_lwwreg}, {assign, <<"baz">>, 5}}]}, a3, Map4),
+    ?assertEqual(6, stat(field_count, Map5)),
+    ?assertEqual(1, stat(duplication, Map5)),
+    %% Updating field {l, riak_dt_lwwreg} merges the duplicates to a single field
+    %% @see apply_ops
+    {ok, Map6} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"bim">>, 6}}]}, a2, Map5),
+    ?assertEqual(0, stat(duplication, Map6)),
+    {ok, Map7} = update({update, [{remove, {l, riak_dt_lwwreg}}]}, a1, Map6),
+    ?assertEqual(5, stat(field_count, Map7)).
 
 -ifdef(EQC).
 -define(NUMTESTS, 1000).
@@ -709,49 +776,5 @@ gen_field_op({_Name, Type}) ->
 
 
 -endif.
-
-%% This test is a regression test for a counter example found by eqc.
-%% The previous version of riak_dt_map used the `dot' from the field
-%% update/creation event as key in `merge_left/3'. Of course multiple
-%% fields can be added/updated at the same time. This means they get
-%% the same `dot'. When merging two replicas, it is possible that one
-%% has removed one or more of the fields added at a particular `dot',
-%% which meant a function clause error in `merge_left/3'. The
-%% structure was wrong, it didn't take into account the possibility
-%% that multiple fields could have the same `dot', when clearly, they
-%% can. This test fails with `dot' as the key for a field in
-%% `merge_left/3', but passes with the current structure, of
-%% `{field(), dot()}' as key.
-dot_key_test() ->
-    {ok, A} = update({update, [{update, {'X', riak_dt_orswot}, {add, <<"a">>}}, {update, {'X', riak_dt_od_flag}, enable}]}, a, new()),
-    B = A,
-    {ok, A2} = update({update, [{remove, {'X', riak_dt_od_flag}}]}, a, A),
-    ?assertEqual([{{'X', riak_dt_orswot}, [<<"a">>]}], value(merge(B, A2))).
-
-stat_test() ->
-    Map = new(),
-    {ok, Map1} = update({update, [{update, {c, riak_dt_emcntr}, increment},
-                                  {update, {s, riak_dt_orswot}, {add, <<"A">>}},
-                                  {update, {m, riak_dt_map}, {update, [{update, {ss, riak_dt_orswot}, {add, 0}}]}},
-                                  {update, {l, riak_dt_lwwreg}, {assign, <<"a">>, 1}},
-                                  {update, {l2, riak_dt_lwwreg}, {assign, <<"b">>, 2}}]}, a1, Map),
-    {ok, Map2} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"foo">>, 3}}]}, a2, Map1),
-    {ok, Map3} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"bar">>, 4}}]}, a3, Map1),
-    Map4 = merge(Map2, Map3),
-    ?assertEqual([{actor_count, 0}, {field_count, 0}, {duplication, 0}, {deferred_length, 0}], stats(Map)),
-    ?assertEqual(3, stat(actor_count, Map4)),
-    ?assertEqual(5, stat(field_count, Map4)),
-    ?assertEqual(undefined, stat(waste_pct, Map4)),
-    ?assertEqual(1, stat(duplication, Map4)),
-    {ok, Map5} = update({update, [{update, {l3, riak_dt_lwwreg}, {assign, <<"baz">>, 5}}]}, a3, Map4),
-    ?assertEqual(6, stat(field_count, Map5)),
-    ?assertEqual(1, stat(duplication, Map5)),
-    %% Updating field {l, riak_dt_lwwreg} merges the duplicates to a single field
-    %% @see apply_ops
-    {ok, Map6} = update({update, [{update, {l, riak_dt_lwwreg}, {assign, <<"bim">>, 6}}]}, a2, Map5),
-    ?assertEqual(0, stat(duplication, Map6)),
-    {ok, Map7} = update({update, [{remove, {l, riak_dt_lwwreg}}]}, a1, Map6),
-    ?assertEqual(5, stat(field_count, Map7)).
-
 
 -endif.

--- a/src/riak_dt_od_flag.erl
+++ b/src/riak_dt_od_flag.erl
@@ -33,7 +33,7 @@
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--export([gen_op/0, init_state/0, update_expected/3, eqc_state_value/1, generate/0, size/1]).
+-export([gen_op/0, gen_op/1, init_state/0, update_expected/3, eqc_state_value/1, generate/0, size/1]).
 -define(NUMTESTS, 1000).
 -endif.
 
@@ -202,8 +202,11 @@ bin_roundtrip_test_() ->
     crdt_statem_eqc:run_binary_rt(?MODULE, ?NUMTESTS).
 
 % EQC generator
+gen_op(_Size) ->
+    gen_op().
+
 gen_op() ->
-    oneof([disable,enable]).
+    elements([disable,enable]).
 
 size({Clock,_}) ->
     length(Clock).

--- a/src/riak_dt_orswot.erl
+++ b/src/riak_dt_orswot.erl
@@ -83,7 +83,7 @@
 
 %% EQC API
 -ifdef(EQC).
--export([gen_op/0, update_expected/3, eqc_state_value/1]).
+-export([gen_op/0, gen_op/1, update_expected/3, eqc_state_value/1]).
 -export([init_state/0, generate/0, size/1]).
 
 -endif.
@@ -582,18 +582,24 @@ generate() ->
 
 %% EQC generator
 gen_op() ->
-    gen_op(fun() -> int() end).
+    ?SIZED(Size, gen_op(Size)).
 
-gen_op(Gen) ->
+gen_op(_Size) ->
+    gen_op2(int()).
+
+gen_op2(Gen) ->
     oneof([gen_updates(Gen), gen_update(Gen)]).
 
 gen_updates(Gen) ->
     {update, non_empty(list(gen_update(Gen)))}.
 
 gen_update(Gen) ->
-    oneof([{add, Gen()}, {remove, Gen()},
-           {add_all, non_empty(list(Gen()))},
-           {remove_all, non_empty(list(Gen()))}]).
+    oneof([{add, Gen}, {remove, Gen},
+           {add_all, non_empty(short_list(Gen))},
+           {remove_all, non_empty(short_list(Gen))}]).
+
+short_list(Gen) ->
+    ?SIZED(Size, resize(Size div 2, list(resize(Size, Gen)))).
 
 init_state() ->
     {0, dict:new()}.

--- a/test/map_eqc.erl
+++ b/test/map_eqc.erl
@@ -59,10 +59,10 @@
                               io:format(user, Str, Args) end, P)).
 
 eqc_test_() ->
-    {timeout, 120, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(100, ?QC_OUT(prop_merge()))))}.
+    {timeout, 200, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(100, ?QC_OUT(prop_merge()))))}.
 
 bin_roundtrip_test_() ->
-    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(crdt_statem_eqc:prop_bin_roundtrip(riak_dt_map)))))}.
+    {timeout, 100, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(crdt_statem_eqc:prop_bin_roundtrip(riak_dt_map)))))}.
 
 
 run() ->

--- a/test/map_eqc.erl
+++ b/test/map_eqc.erl
@@ -35,12 +35,16 @@
           %% can be run (like context ops in the
           %% riak_dt_map)
           deferred=sets:new() ::set(),
-          clock=riak_dt_vclock:fresh() :: riak_dt_vclock:vclock() %% for embedded context operations
+          %% For reset-remove semantic, the field+clock at time of
+          %% removal
+          tombstones=orddict:new() :: orddict:orddict(),
+          %% for embedded context operations
+          clock=riak_dt_vclock:fresh() :: riak_dt_vclock:vclock()
          }).
 
 -type map_model() :: #model{}.
 
--record(state,{replicas=[] :: [binary()], %% Sort of like the ring, upto N*2 ids
+-record(state,{replicas=[],
                replica_data=[] :: [{ActorId :: binary(),
                                   riak_dt_map:map(),
                                   map_model()}],
@@ -55,7 +59,11 @@
                               io:format(user, Str, Args) end, P)).
 
 eqc_test_() ->
-    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(prop_merge()))))}.
+    {timeout, 120, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(100, ?QC_OUT(prop_merge()))))}.
+
+bin_roundtrip_test_() ->
+    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(crdt_statem_eqc:prop_bin_roundtrip(riak_dt_map)))))}.
+
 
 run() ->
     run(?NUMTESTS).
@@ -95,23 +103,20 @@ set_n_next(S, _V, [N]) ->
 make_ring_pre(#state{replicas=Replicas, n=N}) ->
     N > 0 andalso length(Replicas) < N * 2.
 
-make_ring_args(#state{replicas=Replicas, n=N}) ->
-    [Replicas, vector(N, binary(8))].
+make_ring_args(#state{n=N}) ->
+    [vector(N, binary(8))].
 
-make_ring(_,_) ->
-    %% Command args used for next state only
+make_ring(_NewReplicas) ->
     ok.
 
-make_ring_next(S=#state{replicas=Replicas}, _V, [_, NewReplicas0]) ->
-    %% No duplicate replica ids please!
-    NewReplicas = lists:filter(fun(Id) -> not lists:member(Id, Replicas) end, NewReplicas0),
-    S#state{replicas=Replicas ++ NewReplicas}.
+make_ring_next(S=#state{replicas=Replicas}, _V, [NewReplicas]) ->
+    S#state{replicas=lists:umerge(Replicas, NewReplicas)}.
 
 %% ------ Grouped operator: add
 %% Add a new field
 
 add_pre(S) ->
-    replicas_ready(S).
+    false andalso replicas_ready(S).
 
 add_args(#state{replicas=Replicas, replica_data=ReplicaData, counter=Cnt}) ->
     [
@@ -127,10 +132,10 @@ add_args(#state{replicas=Replicas, replica_data=ReplicaData, counter=Cnt}) ->
 %% will be more action on the fields. Learned this from
 %% crdt_statem_eqc having to large a state space and missing bugs.
 gen_field() ->
-    {oneof(['X,', 'Y', 'Z']),
+    {oneof(['X', 'Y', 'Z']),
      oneof([
-            riak_dt_pncounter,
             riak_dt_orswot,
+            riak_dt_emcntr,
             riak_dt_lwwreg,
             riak_dt_map,
             riak_dt_od_flag
@@ -138,6 +143,9 @@ gen_field() ->
 
 gen_field_op({_Name, Type}) ->
     Type:gen_op().
+
+gen_field_and_op() ->
+    ?LET(Field, gen_field(), {Field, gen_field_op(Field)}).
 
 %% Add a Field to the Map
 add(Field, Actor, Cnt, ReplicaData) ->
@@ -256,15 +264,17 @@ ctx_update_pre(S) ->
     replicas_ready(S).
 
 ctx_update_args(#state{replicas=Replicas, replica_data=ReplicaData, counter=Cnt}) ->
-    [
-     ?LET(Field, gen_field(), {Field, gen_field_op(Field)}),
-     elements(Replicas),
-     elements(Replicas),
-     ReplicaData,
-     Cnt
-    ].
+    ?LET({Field, Op}, gen_field_and_op(),
+         [
+          Field,
+          Op,
+          elements(Replicas),
+          elements(Replicas),
+          ReplicaData,
+          Cnt
+         ]).
 
-ctx_update({Field, Op}, From,  To, ReplicaData, Cnt) ->
+ctx_update(Field, Op, From, To, ReplicaData, Cnt) ->
     {CtxMap, CtxModel} = get(From, ReplicaData),
     {ToMap, ToModel} = get(To, ReplicaData),
     Ctx = riak_dt_map:precondition_context(CtxMap),
@@ -273,8 +283,8 @@ ctx_update({Field, Op}, From,  To, ReplicaData, Cnt) ->
     {ok, Model} = model_update_field(Field, Op, To, Cnt, ToModel, ModCtx),
     {To, Map, Model}.
 
-ctx_update_next(S=#state{replica_data=ReplicaData, counter=Cnt}, Res, _Args) ->
-    S#state{replica_data=[Res | ReplicaData], counter=Cnt+1}.
+ctx_update_next(S=#state{replica_data=ReplicaData, counter=Cnt, adds=Adds}, Res, [Field, _Op, _From, To, _, _]) ->
+    S#state{replica_data=[Res | ReplicaData], adds=[{To, Field} | Adds], counter=Cnt+1}.
 
 ctx_update_post(_S, _Args, Res) ->
     post_all(Res, update).
@@ -285,14 +295,16 @@ update_pre(S) ->
     replicas_ready(S).
 
 update_args(#state{replicas=Replicas, replica_data=ReplicaData, counter=Cnt}) ->
-    [
-     ?LET(Field, gen_field(), {Field, gen_field_op(Field)}),
-     elements(Replicas),
-     ReplicaData,
-     Cnt
-    ].
+    ?LET({Field, Op}, gen_field_and_op(),
+         [
+          Field,
+          Op,
+          elements(Replicas),
+          ReplicaData,
+          Cnt
+         ]).
 
-update({Field, Op}, Replica, ReplicaData, Cnt) ->
+update(Field, Op, Replica, ReplicaData, Cnt) ->
     {Map0, Model0} = get(Replica, ReplicaData),
     {ok, Map} = ignore_precon_error(riak_dt_map:update({update, [{update, Field, Op}]}, Replica, Map0), Map0),
     {ok, Model} = model_update_field(Field, Op, Replica, Cnt, Model0,  undefined),
@@ -305,8 +317,8 @@ ignore_precon_error(_, Map) ->
     {ok, Map}.
 
 
-update_next(S=#state{replica_data=ReplicaData, counter=Cnt}, Res, _Args) ->
-    S#state{replica_data=[Res | ReplicaData], counter=Cnt+1}.
+update_next(S=#state{replica_data=ReplicaData, counter=Cnt, adds=Adds}, Res, [Field, _, Actor, _, _]) ->
+    S#state{replica_data=[Res | ReplicaData], adds=[{Actor, Field} | Adds], counter=Cnt+1}.
 
 update_post(_S, _Args, Res) ->
     post_all(Res, update).
@@ -315,31 +327,77 @@ update_post(_S, _Args, Res) ->
 prop_merge() ->
     ?FORALL(Cmds, commands(?MODULE),
             begin
-                {H, S=#state{replicas=Replicas, replica_data=ReplicaData}, Res} = run_commands(?MODULE,Cmds),
+                {_H, _S=#state{replicas=Replicas, replica_data=ReplicaData}, Res} = run_commands(?MODULE,Cmds),
                 %% Check that collapsing all values leads to the same results for Map and the Model
-                {MapValue, ModelValue} = case Replicas of
-                                             [] ->
-                                                 {[], []};
-                                             _L ->
-                                                 %% Get ALL actor's values
-                                                 {Map, Model} = lists:foldl(fun(Actor, {M, Mo}) ->
-                                                                                    {M1, Mo1} = get(Actor, ReplicaData),
-                                                                                    {riak_dt_map:merge(M, M1),
-                                                                                     model_merge(Mo, Mo1)} end,
-                                                                            {riak_dt_map:new(), model_new()},
-                                                                            Replicas),
-                                                 {riak_dt_map:value(Map), model_value(Model)}
-                                         end,
-                aggregate(command_names(Cmds),
-                          pretty_commands(?MODULE,Cmds, {H,S,Res},
-                                          conjunction([{result,  equals(Res, ok)},
-                                                       {values, equals(lists:sort(MapValue), lists:sort(ModelValue))}])
-                                         ))
+                {MapValue, ModelValue}=FinalValues = case Replicas of
+                                                 [] ->
+                                                     {[], []};
+                                                 _L ->
+                                                     %% Get ALL actor's values
+                                                     {Map, Model} = lists:foldl(fun(Actor, {M, Mo}) ->
+                                                                                        {M1, Mo1} = get(Actor, ReplicaData),
+                                                                                        {riak_dt_map:merge(M, M1),
+                                                                                         model_merge(Mo, Mo1)}
+                                                                                end,
+                                                                                {riak_dt_map:new(), model_new()},
+                                                                                lists:usort(Replicas)),
+                                                     {riak_dt_map:value(Map), model_value(Model)}
+                                             end,
+                Actors = lists:foldl(fun({Actor, _Map, _Model}, Acc) ->
+                                 ordsets:add_element(Actor, Acc) end,
+                         ordsets:new(),
+                         ReplicaData),
+                collect(length(Actors), aggregate(command_names(Cmds),
+                          ?WHENFAIL(dump_state(Replicas, FinalValues, ReplicaData),
+                                    conjunction([{results, equals(Res, ok)},
+                                                 {value, equals(lists:sort(MapValue), lists:sort(ModelValue))},
+                                                 {actors, sets:is_subset(sets:from_list(Actors), sets:from_list(Replicas))}])
+                                   )
+                         ))
             end).
 
 %% -----------
 %% Helpers
 %% ----------
+dump_state(Replicas, FinalValues, ReplicaData) ->
+    %% Determine the set of actors (that acted) from the replica data
+    Actors = lists:foldl(fun({Actor, _Map, _Model}, Acc) ->
+                                 ordsets:add_element(Actor, Acc) end,
+                         ordsets:new(),
+                         ReplicaData),
+
+    %% Get the last entry per actor
+    FinalReplicaState = lists:foldl(fun(Actor, Acc) ->
+                                            [lists:keyfind(Actor, 1, ReplicaData) | Acc] end,
+                                    [],
+                                    ordsets:to_list(Actors)),
+
+    %% Get a value for each replica
+    ReplicaValues = lists:foldl(fun({Actor, Map, Model}, Acc) ->
+                                        [{Actor,
+                                          riak_dt_map:value(Map),
+                                          model_value(Model)} | Acc] end,
+                                [],
+                                FinalReplicaState),
+
+    %% Get a CRDT for the actors
+    Merged={MMap, MModel} = lists:foldl(fun({_Actor, Map, Model}, {MM, MMo}) ->
+                                                {riak_dt_map:merge(Map, MM), model_merge(Model, MMo)}
+                                        end,
+                                        {riak_dt_map:new(), model_new()},
+                                        FinalReplicaState),
+
+    %% Get a final merged value to compare to the property's final
+    %% values
+    MergedValues = {riak_dt_map:value(MMap), model_value(MModel)},
+
+    io:format("Helper Values ~p~n", [MergedValues]),
+    io:format("Statem Values ~p~n", [FinalValues]),
+    io:format("Actors ~p ~p~n", [ordsets:to_list(Actors), lists:sort(Replicas)]),
+    io:format("Final State ~p~n", [ReplicaData]),
+    io:format("Replica values~p~n", [ReplicaValues]),
+    io:format("Merged final CRDTs ~p~n", [Merged]).
+
 replicas_ready(#state{replicas=Replicas, n=N}) ->
     length(Replicas) >= N andalso N > 0.
 
@@ -349,9 +407,8 @@ post_all({_, Map, Model}, Cmd) ->
         true ->
             true;
         _ ->
-            {postcondition_failed, "Map and Model don't match", Cmd, Map, Model}
+            {postcondition_failed, "Map and Model don't match", Cmd, Map, Model, riak_dt_map:value(Map), model_value(Model)}
     end.
-
 
 %% if a replica does not yet have replica data, return `new()` for the
 %% Map and Model
@@ -361,7 +418,6 @@ get(Replica, ReplicaData) ->
             {Map, Model};
         false -> {riak_dt_map:new(), model_new()}
     end.
-
 
 %% -----------
 %% Model
@@ -375,7 +431,7 @@ model_add_field({_Name, Type}=Field, Actor, Cnt, Model) ->
                      clock=riak_dt_vclock:merge([[{Actor, Cnt}], Clock])}}.
 
 model_update_field({_Name, Type}=Field, Op, Actor, Cnt, Model, Ctx) ->
-    #model{adds=Adds, removes=Removes, clock=Clock} = Model,
+    #model{adds=Adds, removes=Removes, clock=Clock, tombstones=TS} = Model,
     Clock2 = riak_dt_vclock:merge([[{Actor, Cnt}], Clock]),
     InMap = sets:subtract(Adds, Removes),
     {CRDT0, ToRem} = lists:foldl(fun({F, Value, _X}=E, {CAcc, RAcc}) when F == Field ->
@@ -384,7 +440,14 @@ model_update_field({_Name, Type}=Field, Op, Actor, Cnt, Model, Ctx) ->
                                  end,
                                  {Type:new(), sets:new()},
                                  sets:to_list(InMap)),
-    CRDT = Type:parent_clock(Clock2, CRDT0),
+    CRDT1 = case orddict:find(Field, TS) of
+                error ->
+                    CRDT0;
+                {ok, TSVal} ->
+                    Type:merge(CRDT0, TSVal)
+            end,
+
+    CRDT = Type:parent_clock(Clock2, CRDT1),
     case Type:update(Op, {Actor, Cnt}, CRDT, Ctx) of
         {ok, Updated} ->
             Model2 = Model#model{adds=sets:add_element({Field, Updated, Cnt}, Adds),
@@ -395,48 +458,64 @@ model_update_field({_Name, Type}=Field, Op, Actor, Cnt, Model, Ctx) ->
             {ok, Model}
     end.
 
-model_remove_field(Field, Model) ->
-    #model{adds=Adds, removes=Removes} = Model,
+model_remove_field({_Name, Type}=Field, Model) ->
+    #model{adds=Adds, removes=Removes, tombstones=Tombstones0, clock=Clock} = Model,
     ToRemove = [{F, Val, Token} || {F, Val, Token} <- sets:to_list(Adds), F == Field],
-    Model#model{removes=sets:union(Removes, sets:from_list(ToRemove))}.
+    TS = Type:parent_clock(Clock, Type:new()),
+    Tombstones = orddict:update(Field, fun(T) -> Type:merge(TS, T) end, TS, Tombstones0),
+    Model#model{removes=sets:union(Removes, sets:from_list(ToRemove)), tombstones=Tombstones}.
 
 model_merge(Model1, Model2) ->
-    #model{adds=Adds1, removes=Removes1, deferred=Deferred1, clock=Clock1} = Model1,
-    #model{adds=Adds2, removes=Removes2, deferred=Deferred2, clock=Clock2} = Model2,
+    #model{adds=Adds1, removes=Removes1, deferred=Deferred1, clock=Clock1, tombstones=TS1} = Model1,
+    #model{adds=Adds2, removes=Removes2, deferred=Deferred2, clock=Clock2, tombstones=TS2} = Model2,
     Clock = riak_dt_vclock:merge([Clock1, Clock2]),
     Adds0 = sets:union(Adds1, Adds2),
+    Tombstones = orddict:merge(fun({_Name, Type}, V1, V2) -> Type:merge(V1, V2) end, TS1, TS2),
     Removes0 = sets:union(Removes1, Removes2),
     Deferred0 = sets:union(Deferred1, Deferred2),
-    {Adds, Removes, Deferred} =model_apply_deferred(Adds0, Removes0, Deferred0),
-    #model{adds=Adds, removes=Removes, deferred=Deferred, clock=Clock}.
+    {Adds, Removes, Deferred} = model_apply_deferred(Adds0, Removes0, Deferred0),
+    #model{adds=Adds, removes=Removes, deferred=Deferred, clock=Clock, tombstones=Tombstones}.
 
 model_apply_deferred(Adds, Removes, Deferred) ->
     D2 = sets:subtract(Deferred, Adds),
     ToRem = sets:subtract(Deferred, D2),
     {Adds, sets:union(ToRem, Removes), D2}.
 
-model_ctx_remove(Field, From, To) ->
+model_ctx_remove({_N, Type}=Field, From, To) ->
     %% get adds for Field, any adds for field in ToAdds that are in
     %% FromAdds should be removed any others, put in deferred
-    #model{adds=FromAdds} = From,
-    #model{adds=ToAdds, removes=ToRemoves, deferred=ToDeferred} = To,
+    #model{adds=FromAdds, clock=FromClock} = From,
+    #model{adds=ToAdds, removes=ToRemoves, deferred=ToDeferred, tombstones=TS} = To,
     ToRemove = sets:filter(fun({F, _Val, _Token}) -> F == Field end, FromAdds),
     Defer = sets:subtract(ToRemove, ToAdds),
     Remove = sets:subtract(ToRemove, Defer),
+    Tombstone = Type:parent_clock(FromClock, Type:new()),
+    TS2 = orddict:update(Field, fun(T) -> Type:merge(T, Tombstone) end, Tombstone, TS),
     To#model{removes=sets:union(Remove, ToRemoves),
-           deferred=sets:union(Defer, ToDeferred)}.
+           deferred=sets:union(Defer, ToDeferred),
+            tombstones=TS2}.
 
 model_value(Model) ->
-    #model{adds=Adds, removes=Removes} = Model,
+    #model{adds=Adds, removes=Removes, tombstones=TS} = Model,
     Remaining = sets:subtract(Adds, Removes),
     Res = lists:foldl(fun({{_Name, Type}=Key, Value, _X}, Acc) ->
-                        %% if key is in Acc merge with it and replace
-                        dict:update(Key, fun(V) ->
-                                                 Type:merge(V, Value) end,
-                                    Value, Acc) end,
-                dict:new(),
-                sets:to_list(Remaining)),
-    [{K, Type:value(V)} || {{_Name, Type}=K, V} <- dict:to_list(Res)].
+                              %% if key is in Acc merge with it and replace
+                              dict:update(Key, fun(V) ->
+                                                       Type:merge(V, Value) end,
+                                          Value, Acc) end,
+                      dict:new(),
+                      sets:to_list(Remaining)),
+    Res2 = dict:fold(fun({_N, Type}=Field, Val, Acc) ->
+                             case orddict:find(Field, TS) of
+                                 error ->
+                                     dict:store(Field, Val, Acc);
+                                 {ok, TSVal} ->
+                                     dict:store(Field, Type:merge(TSVal, Val), Acc)
+                             end
+                     end,
+                     dict:new(),
+                     Res),
+    [{K, Type:value(V)} || {{_Name, Type}=K, V} <- dict:to_list(Res2)].
 
 model_ctx(#model{clock=Ctx}) ->
     Ctx.

--- a/test/map_eqc.erl
+++ b/test/map_eqc.erl
@@ -2,7 +2,7 @@
 %%
 %% map_eqc: Drive out the merge bugs the other statem couldn't
 %%
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -28,13 +28,397 @@
 
 -compile(export_all).
 
+-record(state,{replicas=[],
+               %% a unique tag per add
+               counter=1 :: pos_integer(),
+               %% fields that have been added
+               adds=[] :: [{atom(), module()}]
+              }).
+
+-define(NUMTESTS, 1000).
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) ->
+                              io:format(user, Str, Args) end, P)).
+%% @doc eunit runner
+eqc_test_() ->
+    {timeout, 200, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(100, ?QC_OUT(prop_merge()))))}.
+
+%% @doc eunit runner for bin roundtrip
+bin_roundtrip_test_() ->
+    {timeout, 100, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(crdt_statem_eqc:prop_bin_roundtrip(riak_dt_map)))))}.
+
+%% @doc shell convenience, run eqc property 1000 times.
+run() ->
+    run(?NUMTESTS).
+
+%% @doc shell convenience, run eqc property `Count' times
+run(Count) ->
+    eqc:quickcheck(eqc:numtests(Count, prop_merge())).
+
+%% @doc shell convenience, check eqc property (last failing counter example)
+check() ->
+    eqc:check(prop_merge()).
+
+%% Initialize the state
+-spec initial_state() -> eqc_statem:symbolic_state().
+initial_state() ->
+    #state{}.
+
+%% ------ Grouped operator: create_replica
+create_replica_pre(#state{replicas=Replicas}) ->
+    length(Replicas) < 10.
+
+%% @doc create_replica_arge - Generate a replica
+create_replica_args(_S) ->
+    %% don't waste time shrinking actor id binaries
+    [noshrink(binary(8))].
+
+%% @doc create_replica_pre - Don't duplicate replicas
+-spec create_replica_pre(S :: eqc_statem:symbolic_state(),
+                         Args :: [term()]) -> boolean().
+create_replica_pre(#state{replicas=Replicas}, [Id]) ->
+    not lists:member(Id, Replicas).
+
+%% @doc store new replica ID and bottom map/model in ets
+create_replica(Id) ->
+    ets:insert(map_eqc, {Id, riak_dt_map:new(), model_new()}).
+
+%% @doc create_replica_next - Add replica ID to state
+-spec create_replica_next(S :: eqc_statem:symbolic_state(),
+                          V :: eqc_statem:var(),
+                          Args :: [term()]) -> eqc_statem:symbolic_state().
+create_replica_next(S=#state{replicas=R0}, _Value, [Id]) ->
+    S#state{replicas=R0++[Id]}.
+
+
+%% ------ Grouped operator: remove
+%% @doc remove, but only something that has been added already
+remove_pre(#state{replicas=Replicas, adds=Adds}) ->
+    Replicas /= [] andalso Adds /= [].
+
+%% @doc remove something that has been added already from any replica
+remove_args(#state{adds=Adds, replicas=Replicas}) ->
+    [
+     elements(Replicas),
+     elements(Adds) %% A Field that has been added
+    ].
+
+%% @doc correct shrinking
+remove_pre(#state{replicas=Replicas}, [Replica, _]) ->
+    lists:member(Replica, Replicas).
+
+%% @doc perform a remove operation, remove `Field' from Map/Model at
+%% `Replica'
+remove(Replica, Field) ->
+    [{Replica, Map, Model}] = ets:lookup(map_eqc, Replica),
+    %% even though we only remove what has been added, there is no
+    %% guarantee a merge from another replica hasn't led to the
+    %% Field being removed already, so ignore precon errors (they
+    %% don't change state)
+    {ok, Map2} = ignore_precon_error(riak_dt_map:update({update, [{remove, Field}]}, Replica, Map), Map),
+    Model2 = model_remove_field(Field, Model),
+    ets:insert(map_eqc, {Replica, Map2, Model2}),
+    {Map2, Model2}.
+
+%% @doc remove post condition, @see post_all/2
+remove_post(_S, [_Replica, Field], Res) ->
+    post_all(Res, remove) andalso field_not_present(Field, Res).
+
+%% ------ Grouped operator: ctx_remove
+%% @doc remove, but with a context
+ctx_remove_pre(#state{replicas=Replicas, adds=Adds}) ->
+        Replicas /= [] andalso Adds /= [].
+
+%% @doc generate ctx rmeove args
+ctx_remove_args(#state{replicas=Replicas, adds=Adds}) ->
+    [
+     elements(Replicas),        %% read from
+     elements(Replicas),          %% send op to
+     elements(Adds)       %% which field to remove
+    ].
+
+%% @doc ensure correct shrinking
+ctx_remove_pre(#state{replicas=Replicas, adds=Adds}, [From, To, Field]) ->
+    lists:member(From, Replicas) andalso lists:member(To, Replicas)
+        andalso lists:member(Field, Adds).
+
+%% @doc dynamic precondition, only context remove if the `Field' is in
+%% the `From' replicas
+ctx_remove_dynamicpre(_S, [From, _To, Field]) ->
+    [{From, Map, _Model}] = ets:lookup(map_eqc, From),
+    lists:keymember(Field, 1, riak_dt_map:value(Map)).
+
+%% @doc perform a context remove on the map and model using context
+%% from `From'
+ctx_remove(From, To, Field) ->
+    [{From, FromMap, FromModel}] = ets:lookup(map_eqc, From),
+    [{To, ToMap, ToModel}] = ets:lookup(map_eqc, To),
+    Ctx = riak_dt_map:precondition_context(FromMap),
+    {ok, Map} = riak_dt_map:update({update, [{remove, Field}]}, To, ToMap, Ctx),
+    Model = model_ctx_remove(Field, FromModel, ToModel),
+    ets:insert(map_eqc, {To, Map, Model}),
+    {Map, Model}.
+
+%% @doc @see post_all/2
+ctx_remove_post(_S, _Args, Res) ->
+    post_all(Res, ctx_remove).
+
+%% ------ Grouped operator: replicate Merges two replicas' values.
+
+%% @doc must be a replica at least.
+replicate_pre(#state{replicas=Replicas}) ->
+    Replicas /= [].
+
+%% @doc chose from/to replicas, can be the same
+replicate_args(#state{replicas=Replicas}) ->
+    [
+     elements(Replicas), %% Replicate from
+     elements(Replicas) %% Replicate to
+    ].
+
+%% @doc replicate_pre - shrink correctly
+-spec replicate_pre(S :: eqc_statem:symbolic_state(),
+                    Args :: [term()]) -> boolean().
+replicate_pre(#state{replicas=Replicas}, [From, To]) ->
+    lists:member(From, Replicas) andalso lists:member(To, Replicas).
+
+%% @doc Replicate a CRDT from `From' to `To'
+replicate(From, To) ->
+    [{From, FromMap, FromModel}] = ets:lookup(map_eqc, From),
+    [{To, ToMap, ToModel}] = ets:lookup(map_eqc, To),
+
+    Map = riak_dt_map:merge(FromMap, ToMap),
+    Model = model_merge(FromModel, ToModel),
+
+    ets:insert(map_eqc, {To, Map, Model}),
+    {Map, Model}.
+
+%% @doc @see post_all/2
+replicate_post(_S, _Args, Res) ->
+    post_all(Res, rep).
+
+%% ------ Grouped operator: ctx_update
+%% Update a Field in the Map, using the Map context
+
+%% @doc there must be at least one replica
+ctx_update_pre(#state{replicas=Replicas}) ->
+    Replicas /= [].
+
+%% @doc generate an operation
+ctx_update_args(#state{replicas=Replicas, counter=Cnt}) ->
+    ?LET({Field, Op}, gen_field_and_op(),
+         [
+          Field,
+          Op,
+          elements(Replicas),
+          elements(Replicas),
+          Cnt
+         ]).
+
+%% @doc ensure correct shrinking
+ctx_update_pre(#state{replicas=Replicas}, [_Field, _Op, From, To, _Cnt]) ->
+    lists:member(From, Replicas) andalso lists:member(To, Replicas).
+
+%% @doc much like context_remove, get a contet from `From' and apply
+%% `Op' at `To'
+ctx_update(Field, Op, From, To, Cnt) ->
+    [{From, CtxMap, CtxModel}] = ets:lookup(map_eqc, From),
+    [{To, ToMap, ToModel}] = ets:lookup(map_eqc, To),
+
+    Ctx = riak_dt_map:precondition_context(CtxMap),
+    ModCtx = model_ctx(CtxModel),
+    {ok, Map} = riak_dt_map:update({update, [{update, Field, Op}]}, To, ToMap, Ctx),
+    {ok, Model} = model_update_field(Field, Op, To, Cnt, ToModel, ModCtx),
+
+    ets:insert(map_eqc, {To, Map, Model}),
+    {Map, Model}.
+
+%% @doc update the model state, incrementing the counter represents logical time.
+ctx_update_next(S=#state{counter=Cnt, adds=Adds}, _Res, [Field, _Op, _From, _To, _Cnt]) ->
+    S#state{adds=lists:umerge(Adds, [Field]), counter=Cnt+1}.
+
+%% @doc @see post_all/2
+ctx_update_post(_S, _Args, Res) ->
+    post_all(Res, update).
+
+%% ------ Grouped operator: update
+%% Update a Field in the Map
+
+%% @doc there must be at least one replica
+update_pre(#state{replicas=Replicas}) ->
+    Replicas /= [].
+
+%% @doc choose a field, operation and replica
+update_args(#state{replicas=Replicas, counter=Cnt}) ->
+    ?LET({Field, Op}, gen_field_and_op(),
+         [
+          Field,
+          Op,
+          elements(Replicas),
+          Cnt
+         ]).
+
+%% @doc shrink correctly
+update_pre(#state{replicas=Replicas}, [_Field, _Op, Replica, _Cnt]) ->
+    lists:member(Replica, Replicas).
+
+%% @doc apply `Op' to `Field' at `Replica'
+update(Field, Op, Replica, Cnt) ->
+    [{Replica, Map0, Model0}] = ets:lookup(map_eqc, Replica),
+
+    {ok, Map} = ignore_precon_error(riak_dt_map:update({update, [{update, Field, Op}]}, Replica, Map0), Map0),
+    {ok, Model} = model_update_field(Field, Op, Replica, Cnt, Model0,  undefined),
+
+    ets:insert(map_eqc, {Replica, Map, Model}),
+    {Map, Model}.
+
+%% @doc increment the time counter, and add this field to adds as a
+%% candidate to be removed later.
+update_next(S=#state{counter=Cnt, adds=Adds}, _Res, [Field, _, _, _]) ->
+    S#state{adds=lists:umerge(Adds, [Field]), counter=Cnt+1}.
+
+%% @doc @see post_all/2
+update_post(_S, _Args, Res) ->
+    post_all(Res, update).
+
+%% @doc Tests the property that a riak_dt_map is equivalent to the Map
+%% Model. The Map Model is based roughly on an or-set design. Inspired
+%% by a draft spec in sent in private email by Carlos Baquero. The
+%% model extends the spec to onclude context operations, deferred
+%% operations, and reset-remove semantic (with tombstones.)
+prop_merge() ->
+    ?FORALL(Cmds, commands(?MODULE),
+            begin
+                %% store state in eqc, external to statem state
+                ets:new(map_eqc, [named_table, set]),
+                {H, S, Res} = run_commands(?MODULE,Cmds),
+                ReplicaData =  ets:tab2list(map_eqc),
+                %% Check that merging all values leads to the same results for Map and the Model
+                {Map, Model} = lists:foldl(fun({_Actor, InMap, InModel}, {M, Mo}) ->
+                                                   {riak_dt_map:merge(M, InMap),
+                                                    model_merge(Mo, InModel)}
+                                           end,
+                                           {riak_dt_map:new(), model_new()},
+                                           ReplicaData),
+                MapValue = riak_dt_map:value(Map),
+                ModelValue = model_value(Model),
+                %% clean up
+                ets:delete(map_eqc),
+                %% prop
+                pretty_commands(?MODULE, Cmds, {H, S, Res},
+                                measure(actors, length(ReplicaData),
+                                        measure(length, length(MapValue),
+                                                measure(depth, map_depth(MapValue),
+                                                        aggregate(command_names(Cmds),
+                                                                  conjunction([{results, equals(Res, ok)},
+                                                                               {value, equals(lists:sort(MapValue), lists:sort(ModelValue))}
+                                                                              ])
+                                                                 )))))
+            end).
+
+%% -----------
+%% Generators
+%% ----------
+
+%% @doc Keep the number of possible field names down to a minimum. The
+%% smaller state space makes EQC more likely to find bugs since there
+%% will be more action on the fields. Learned this from
+%% crdt_statem_eqc having to large a state space and missing bugs.
+gen_field() ->
+    {growingelements(['A', 'B', 'C', 'D', 'X', 'Y', 'Z']),
+     elements([
+               riak_dt_orswot,
+               riak_dt_emcntr,
+               riak_dt_lwwreg,
+               riak_dt_map,
+               riak_dt_od_flag
+              ])}.
+
+%% @use the generated field to generate an op. Delegates to type. Some
+%% Type generators are recursive, pass in Size to limit the depth of
+%% recusrions. @see riak_dt_map:gen_op/1.
+gen_field_op({_Name, Type}) ->
+    ?SIZED(Size, Type:gen_op(Size)).
+
+%% @doc geneate a field, and a valid operation for the field
+gen_field_and_op() ->
+    ?LET(Field, gen_field(), {Field, gen_field_op(Field)}).
+
+
+%% -----------
+%% Helpers
+%% ----------
+
+%% @doc how deeply nested is `Map'? Recurse down the Map and return
+%% the deepest nesting. A depth of `1' means only a top-level Map. `2'
+%% means a map in the seocnd level, `3' in the third, and so on.
+map_depth(Map) ->
+    map_depth(Map, 1).
+
+%% @doc iterate a maps fields, and recurse down map fields to get a
+%% max depth.
+map_depth(Map, D) ->
+    lists:foldl(fun({{_, riak_dt_map}, SubMap}, MaxDepth) ->
+                        Depth = map_depth(SubMap, D+1),
+                        max(MaxDepth, Depth);
+                   (_, Depth) ->
+                        Depth
+                end,
+                D,
+                Map).
+
+%% @doc precondition errors don't change the state of a map, so ignore
+%% them.
+ignore_precon_error({ok, NewMap}, _) ->
+    {ok, NewMap};
+ignore_precon_error(_, Map) ->
+    {ok, Map}.
+
+%% @doc for all mutating operations enusre that the state at the
+%% mutated replica is equal for the map and the model
+post_all({Map, Model}, Cmd) ->
+    %% What matters is that both types have the exact same results.
+    case lists:sort(riak_dt_map:value(Map)) == lists:sort(model_value(Model)) of
+        true ->
+            true;
+        _ ->
+            {postcondition_failed, "Map and Model don't match", Cmd, Map, Model, riak_dt_map:value(Map), model_value(Model)}
+    end.
+
+%% @doc `true' if `Field' is not in `Map'
+field_not_present(Field, {Map, _Model}) ->
+    case lists:keymember(Field, 1, riak_dt_map:value(Map)) of
+        false ->
+            true;
+        true ->
+            {Field, present, Map}
+    end.
+
+%% -----------
+%% Model
+%% ----------
+
+%% The model has to be a Map CRDT, with the same deferred operations
+%% and reset-remove semantics as riak_dt_map. Luckily it has no
+%% efficiency constraints. It's modelled as three lists. Added fields,
+%% removed fields, and deferred remove operations. There is also an
+%% entry for tombstones, and vclock. Whenever a field is removed, an
+%% empty CRDT of that fields type is stored, with the clock at removal
+%% time, in tombstones. Merging a fields value with this tombstone
+%% ensures reset-remove semantics. The vector clock entry is only for
+%% tombstones and context operations. The add/remove sets use a unique
+%% tag, like in OR-Set, for elements.
+
 -record(model, {
-          adds=sets:new() :: set(), %% Things added to the Map
-          removes=sets:new() :: set(), %% Tombstones
+          %% Things added to the Map, a Set really, but uses a list
+          %% for ease of reading in case of a counter example
+          adds=[],
+          %% Tombstones of things removed from the map
+          removes=[],
           %% Removes that are waiting for adds before they
           %% can be run (like context ops in the
           %% riak_dt_map)
-          deferred=sets:new() ::set(),
+          deferred=[],
           %% For reset-remove semantic, the field+clock at time of
           %% removal
           tombstones=orddict:new() :: orddict:orddict(),
@@ -44,470 +428,120 @@
 
 -type map_model() :: #model{}.
 
--record(state,{replicas=[],
-               replica_data=[] :: [{ActorId :: binary(),
-                                  riak_dt_map:map(),
-                                  map_model()}],
-               n=0 :: pos_integer(), %% Generated number of replicas
-               counter=1 :: pos_integer(), %% a unique tag per add
-               adds=[] :: [{ActorId :: binary(), atom()}] %% things that have been added
-              }).
-
--define(NUMTESTS, 1000).
--define(QC_OUT(P),
-        eqc:on_output(fun(Str, Args) ->
-                              io:format(user, Str, Args) end, P)).
-
-eqc_test_() ->
-    {timeout, 200, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(100, ?QC_OUT(prop_merge()))))}.
-
-bin_roundtrip_test_() ->
-    {timeout, 100, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(crdt_statem_eqc:prop_bin_roundtrip(riak_dt_map)))))}.
-
-
-run() ->
-    run(?NUMTESTS).
-
-run(Count) ->
-    eqc:quickcheck(eqc:numtests(Count, prop_merge())).
-
-check() ->
-    eqc:check(prop_merge()).
-
-%% Initialize the state
--spec initial_state() -> eqc_statem:symbolic_state().
-initial_state() ->
-    #state{}.
-
-
-%% ------ Grouped operator: set_nr
-%% Only set N if N has not been set (ie run once, as the first command)
-set_n_pre(#state{n=N}) ->
-     N == 0.
-
-%% Choose how many replicas to have in the system
-set_n_args(_S) ->
-    [choose(2, 10)].
-
-set_n(_) ->
-    %% Command args used for next state only
-    ok.
-
-set_n_next(S, _V, [N]) ->
-    S#state{n=N}.
-
-%% ------ Grouped operator: make_ring
-%%
-%% Generate a bunch of replicas, only runs if N is set, and until
-%% "enough" are generated (N*2) is more than enough.
-make_ring_pre(#state{replicas=Replicas, n=N}) ->
-    N > 0 andalso length(Replicas) < N * 2.
-
-make_ring_args(#state{n=N}) ->
-    [vector(N, binary(8))].
-
-make_ring(_NewReplicas) ->
-    ok.
-
-make_ring_next(S=#state{replicas=Replicas}, _V, [NewReplicas]) ->
-    S#state{replicas=lists:umerge(Replicas, NewReplicas)}.
-
-%% ------ Grouped operator: add
-%% Add a new field
-
-add_pre(S) ->
-    false andalso replicas_ready(S).
-
-add_args(#state{replicas=Replicas, replica_data=ReplicaData, counter=Cnt}) ->
-    [
-     %% a new field
-     gen_field(),
-     elements(Replicas), % The replica
-     Cnt,
-     ReplicaData %% The existing vnode data
-    ].
-
-%% Keep the number of possible field names down to a minimum. The
-%% smaller state space makes EQC more likely to find bugs since there
-%% will be more action on the fields. Learned this from
-%% crdt_statem_eqc having to large a state space and missing bugs.
-gen_field() ->
-    {oneof(['X', 'Y', 'Z']),
-     oneof([
-            riak_dt_orswot,
-            riak_dt_emcntr,
-            riak_dt_lwwreg,
-            riak_dt_map,
-            riak_dt_od_flag
-           ])}.
-
-gen_field_op({_Name, Type}) ->
-    Type:gen_op().
-
-gen_field_and_op() ->
-    ?LET(Field, gen_field(), {Field, gen_field_op(Field)}).
-
-%% Add a Field to the Map
-add(Field, Actor, Cnt, ReplicaData) ->
-    {Map, Model} = get(Actor, ReplicaData),
-    {ok, Map2} = riak_dt_map:update({update, [{add, Field}]}, Actor, Map),
-    {ok, Model2} = model_add_field(Field, Actor, Cnt, Model),
-    {Actor, Map2, Model2}.
-
-add_next(S=#state{replica_data=ReplicaData, adds=Adds, counter=Cnt}, Res, [Field, Actor, _, _]) ->
-    S#state{replica_data=[Res | ReplicaData], adds=[{Actor, Field} | Adds], counter=Cnt+1}.
-
-add_post(_S, _Args, Res) ->
-    post_all(Res, add).
-
-%% ------ Grouped operator: remove
-
-%% remove, but only something that has been added already
-remove_pre(S=#state{adds=Adds}) ->
-    replicas_ready(S) andalso Adds /= [].
-
-remove_args(#state{adds=Adds, replica_data=ReplicaData}) ->
-    [
-     elements(Adds), %% A Field that has been added
-     ReplicaData %% All the vnode data
-    ].
-
-remove_pre(#state{adds=Adds}, [Add, _]) ->
-    lists:member(Add, Adds).
-
-remove({Replica, Field}, ReplicaData) ->
-    {Map, Model} = get(Replica, ReplicaData),
-    %% even though we only remove what has been added, there is no
-    %% guarantee a merge from another replica hasn't led to the
-    %% Field being removed already, so ignore precon errors (they
-    %% don't change state)
-    {ok, Map2} = ignore_precon_error(riak_dt_map:update({update, [{remove, Field}]}, Replica, Map), Map),
-    Model2 = model_remove_field(Field, Model),
-    {Replica, Map2, Model2}.
-
-remove_next(S=#state{replica_data=ReplicaData, adds=Adds}, Res, [Add, _]) ->
-    S#state{replica_data=[Res | ReplicaData], adds=lists:delete(Add, Adds)}.
-
-remove_post(_S, _Args, Res) ->
-    post_all(Res, remove).
-
-%% ------ Grouped operator: ctx_remove
-%% remove, but with a context
-ctx_remove_pre(S=#state{replica_data=ReplicaData, adds=Adds}) ->
-    replicas_ready(S) andalso Adds /= [] andalso ReplicaData /= [].
-
-ctx_remove_args(#state{replicas=Replicas, replica_data=ReplicaData, adds=Adds}) ->
-    ?LET({{From, Field}, To}, {elements(Adds), elements(Replicas)},
-         [
-          From,        %% read from
-          To,          %% send op to
-          Field,       %% which field to remove
-          ReplicaData  %% All the vnode data
-         ]).
-
-%% Should we send ctx ops to originating replica?
-ctx_remove_pre(_S, [VN, VN, _, _]) ->
-    false;
-ctx_remove_pre(_S, [_VN1, _VN2, _, _]) ->
-    true.
-
-ctx_remove(From, To, Field, ReplicaData) ->
-    {FromMap, FromModel} = get(From, ReplicaData),
-    {ToMap, ToModel} = get(To, ReplicaData),
-    Ctx = riak_dt_map:precondition_context(FromMap),
-    {ok, Map} = riak_dt_map:update({update, [{remove, Field}]}, To, ToMap, Ctx),
-    Model = model_ctx_remove(Field, FromModel, ToModel),
-    {To, Map, Model}.
-
-
-ctx_remove_next(S=#state{replica_data=ReplicaData}, Res, _) ->
-    S#state{replica_data=[Res | ReplicaData]}.
-
-ctx_remove_post(_S, _Args, Res) ->
-    post_all(Res, ctx_remove).
-
-%% ------ Grouped operator: replicate
-%% Merge two replicas' values
-replicate_pre(S=#state{replica_data=ReplicaData}) ->
-    replicas_ready(S) andalso ReplicaData /= [].
-
-replicate_args(#state{replicas=Replicas, replica_data=ReplicaData}) ->
-    [
-     elements(Replicas), %% Replicate from
-     elements(Replicas), %% Replicate to
-     ReplicaData
-    ].
-
-%% Don't replicate to oneself
-replicate_pre(_S, [VN, VN, _]) ->
-    false;
-replicate_pre(_S, [_VN1, _VN2, _]) ->
-    true.
-
-%% Replicate a CRDT from `From' to `To'
-replicate(From, To, ReplicaData) ->
-    {FromMap, FromModel} = get(From, ReplicaData),
-    {ToMap, ToModel} = get(To, ReplicaData),
-    Map = riak_dt_map:merge(FromMap, ToMap),
-    Model = model_merge(FromModel, ToModel),
-    {To, Map, Model}.
-
-replicate_next(S=#state{replica_data=ReplicaData}, Res, _Args) ->
-    S#state{replica_data=[Res | ReplicaData]}.
-
-replicate_post(_S, _Args, Res) ->
-    post_all(Res, rep).
-
-%% ------ Grouped operator: ctx_update
-%% Update a Field in the Map, using the Map context
-ctx_update_pre(S) ->
-    replicas_ready(S).
-
-ctx_update_args(#state{replicas=Replicas, replica_data=ReplicaData, counter=Cnt}) ->
-    ?LET({Field, Op}, gen_field_and_op(),
-         [
-          Field,
-          Op,
-          elements(Replicas),
-          elements(Replicas),
-          ReplicaData,
-          Cnt
-         ]).
-
-ctx_update(Field, Op, From, To, ReplicaData, Cnt) ->
-    {CtxMap, CtxModel} = get(From, ReplicaData),
-    {ToMap, ToModel} = get(To, ReplicaData),
-    Ctx = riak_dt_map:precondition_context(CtxMap),
-    ModCtx = model_ctx(CtxModel),
-    {ok, Map} = riak_dt_map:update({update, [{update, Field, Op}]}, To, ToMap, Ctx),
-    {ok, Model} = model_update_field(Field, Op, To, Cnt, ToModel, ModCtx),
-    {To, Map, Model}.
-
-ctx_update_next(S=#state{replica_data=ReplicaData, counter=Cnt, adds=Adds}, Res, [Field, _Op, _From, To, _, _]) ->
-    S#state{replica_data=[Res | ReplicaData], adds=[{To, Field} | Adds], counter=Cnt+1}.
-
-ctx_update_post(_S, _Args, Res) ->
-    post_all(Res, update).
-
-%% ------ Grouped operator: update
-%% Update a Field in the Map
-update_pre(S) ->
-    replicas_ready(S).
-
-update_args(#state{replicas=Replicas, replica_data=ReplicaData, counter=Cnt}) ->
-    ?LET({Field, Op}, gen_field_and_op(),
-         [
-          Field,
-          Op,
-          elements(Replicas),
-          ReplicaData,
-          Cnt
-         ]).
-
-update(Field, Op, Replica, ReplicaData, Cnt) ->
-    {Map0, Model0} = get(Replica, ReplicaData),
-    {ok, Map} = ignore_precon_error(riak_dt_map:update({update, [{update, Field, Op}]}, Replica, Map0), Map0),
-    {ok, Model} = model_update_field(Field, Op, Replica, Cnt, Model0,  undefined),
-    {Replica, Map, Model}.
-
-%% precondition errors don't change the state of a map
-ignore_precon_error({ok, NewMap}, _) ->
-    {ok, NewMap};
-ignore_precon_error(_, Map) ->
-    {ok, Map}.
-
-
-update_next(S=#state{replica_data=ReplicaData, counter=Cnt, adds=Adds}, Res, [Field, _, Actor, _, _]) ->
-    S#state{replica_data=[Res | ReplicaData], adds=[{Actor, Field} | Adds], counter=Cnt+1}.
-
-update_post(_S, _Args, Res) ->
-    post_all(Res, update).
-
-%% Tests the property that an Map is equivalent to the Map Model
-prop_merge() ->
-    ?FORALL(Cmds, commands(?MODULE),
-            begin
-                {_H, _S=#state{replicas=Replicas, replica_data=ReplicaData}, Res} = run_commands(?MODULE,Cmds),
-                %% Check that collapsing all values leads to the same results for Map and the Model
-                {MapValue, ModelValue}=FinalValues = case Replicas of
-                                                         [] ->
-                                                             {[], []};
-                                                         _L ->
-                                                             %% Get ALL actor's values
-                                                             {Map, Model} = lists:foldl(fun(Actor, {M, Mo}) ->
-                                                                                                {M1, Mo1} = get(Actor, ReplicaData),
-                                                                                                {riak_dt_map:merge(M, M1),
-                                                                                                 model_merge(Mo, Mo1)}
-                                                                                        end,
-                                                                                        {riak_dt_map:new(), model_new()},
-                                                                                        lists:usort(Replicas)),
-                                                             {riak_dt_map:value(Map),
-                                                              model_value(Model)}
-                                                     end,
-
-                Actors = lists:foldl(fun({Actor, _Map, _Model}, Acc) ->
-                                             ordsets:add_element(Actor, Acc) end,
-                                     ordsets:new(),
-                                     ReplicaData),
-
-                collect(length(Actors), aggregate(command_names(Cmds),
-                                                  ?WHENFAIL(dump_state(Replicas, FinalValues, ReplicaData),
-                                                            conjunction([{results, equals(Res, ok)},
-                                                                         {value, equals(lists:sort(MapValue), lists:sort(ModelValue))},
-                                                                         {actors, sets:is_subset(sets:from_list(Actors), sets:from_list(Replicas))}])
-                                                           )
-                                                 ))
-            end).
-
-%% -----------
-%% Helpers
-%% ----------
-dump_state(Replicas, FinalValues, ReplicaData) ->
-    %% Determine the set of actors (that acted) from the replica data
-    Actors = lists:foldl(fun({Actor, _Map, _Model}, Acc) ->
-                                 ordsets:add_element(Actor, Acc) end,
-                         ordsets:new(),
-                         ReplicaData),
-
-    %% Get the last entry per actor
-    FinalReplicaState = lists:foldl(fun(Actor, Acc) ->
-                                            [lists:keyfind(Actor, 1, ReplicaData) | Acc] end,
-                                    [],
-                                    ordsets:to_list(Actors)),
-
-    %% Get a value for each replica
-    ReplicaValues = lists:foldl(fun({Actor, Map, Model}, Acc) ->
-                                        [{Actor,
-                                          riak_dt_map:value(Map),
-                                          model_value(Model)} | Acc] end,
-                                [],
-                                FinalReplicaState),
-
-    %% Get a CRDT for the actors
-    Merged={MMap, MModel} = lists:foldl(fun({_Actor, Map, Model}, {MM, MMo}) ->
-                                                {riak_dt_map:merge(Map, MM), model_merge(Model, MMo)}
-                                        end,
-                                        {riak_dt_map:new(), model_new()},
-                                        FinalReplicaState),
-
-    %% Get a final merged value to compare to the property's final
-    %% values
-    MergedValues = {riak_dt_map:value(MMap), model_value(MModel)},
-
-    io:format("Helper Values ~p~n", [MergedValues]),
-    io:format("Statem Values ~p~n", [FinalValues]),
-    io:format("Actors ~p ~p~n", [ordsets:to_list(Actors), lists:sort(Replicas)]),
-    io:format("Final State ~p~n", [ReplicaData]),
-    io:format("Replica values~p~n", [ReplicaValues]),
-    io:format("Merged final CRDTs ~p~n", [Merged]).
-
-replicas_ready(#state{replicas=Replicas, n=N}) ->
-    length(Replicas) >= N andalso N > 0.
-
-post_all({_, Map, Model}, Cmd) ->
-    %% What matters is that both types have the exact same results.
-    case lists:sort(riak_dt_map:value(Map)) == lists:sort(model_value(Model)) of
-        true ->
-            true;
-        _ ->
-            {postcondition_failed, "Map and Model don't match", Cmd, Map, Model, riak_dt_map:value(Map), model_value(Model)}
-    end.
-
-%% if a replica does not yet have replica data, return `new()` for the
-%% Map and Model
-get(Replica, ReplicaData) ->
-    case lists:keyfind(Replica, 1, ReplicaData) of
-        {Replica, Map, Model} ->
-            {Map, Model};
-        false -> {riak_dt_map:new(), model_new()}
-    end.
-
-%% -----------
-%% Model
-%% ----------
+%% @doc create a new model. This is the bottom element.
+-spec model_new() -> map_model().
 model_new() ->
     #model{}.
 
-model_add_field({_Name, Type}=Field, Actor, Cnt, Model) ->
-    #model{adds=Adds, clock=Clock} = Model,
-    {ok, Model#model{adds=sets:add_element({Field, Type:new(), Cnt}, Adds),
-                     clock=riak_dt_vclock:merge([[{Actor, Cnt}], Clock])}}.
-
+%% @doc update `Field' with `Op', by `Actor' at time `Cnt'. very
+%% similar to riak_dt_map.
+-spec model_update_field({atom(), module()}, term(), binary(), pos_integer(),
+                         map_model(), undefined | riak_dt_vclock:vclock()) -> map_model().
 model_update_field({_Name, Type}=Field, Op, Actor, Cnt, Model, Ctx) ->
     #model{adds=Adds, removes=Removes, clock=Clock, tombstones=TS} = Model,
+    %% generate a new clock
     Clock2 = riak_dt_vclock:merge([[{Actor, Cnt}], Clock]),
-    InMap = sets:subtract(Adds, Removes),
+    %% Get those fields that are present, that is, only in the Adds
+    %% set
+    InMap = lists:subtract(Adds, Removes),
+    %% Merge all present values to get a current CRDT, and add each
+    %% field entry we merge to a set so we can move them to `removed'
     {CRDT0, ToRem} = lists:foldl(fun({F, Value, _X}=E, {CAcc, RAcc}) when F == Field ->
-                                         {Type:merge(CAcc, Value), sets:add_element(E, RAcc)};
+                                         {Type:merge(CAcc, Value), lists:umerge([E], RAcc)};
                                     (_, Acc) -> Acc
                                  end,
-                                 {Type:new(), sets:new()},
-                                 sets:to_list(InMap)),
+                                 {Type:new(), []},
+                                 InMap),
+    %% If we have a tombstone for this field, merge with it to ensure
+    %% reset-remove
     CRDT1 = case orddict:find(Field, TS) of
                 error ->
                     CRDT0;
                 {ok, TSVal} ->
                     Type:merge(CRDT0, TSVal)
             end,
-
+    %% Update the clock to ensure a shared causal context
     CRDT = Type:parent_clock(Clock2, CRDT1),
+    %% Apply the operation
     case Type:update(Op, {Actor, Cnt}, CRDT, Ctx) of
         {ok, Updated} ->
-            Model2 = Model#model{adds=sets:add_element({Field, Updated, Cnt}, Adds),
-                                 removes=sets:union(ToRem, Removes),
+            %% Op succeded, store the new value as the field, using
+            %% `Cnt' (which is time since the statem acts serially) as
+            %% a unique tag.
+            Model2 = Model#model{adds=lists:umerge([{Field, Updated, Cnt}], Adds),
+                                 removes=lists:umerge(ToRem, Removes),
                                  clock=Clock2},
             {ok, Model2};
         _ ->
+            %% if the op failed just return the state un changed
             {ok, Model}
     end.
 
+%% @doc remove a field from the model, doesn't enforce a precondition,
+%% removing a non-present field does nothing.
+-spec model_remove_field({atom(), module()}, map_model()) -> map_model().
 model_remove_field({_Name, Type}=Field, Model) ->
     #model{adds=Adds, removes=Removes, tombstones=Tombstones0, clock=Clock} = Model,
-    ToRemove = [{F, Val, Token} || {F, Val, Token} <- sets:to_list(Adds), F == Field],
+    ToRemove = [{F, Val, Token} || {F, Val, Token} <- Adds, F == Field],
     TS = Type:parent_clock(Clock, Type:new()),
     Tombstones = orddict:update(Field, fun(T) -> Type:merge(TS, T) end, TS, Tombstones0),
-    Model#model{removes=sets:union(Removes, sets:from_list(ToRemove)), tombstones=Tombstones}.
+    Model#model{removes=lists:umerge(Removes, ToRemove), tombstones=Tombstones}.
 
+%% @doc merge two models. Very simple since the model truley always
+%% grows, it is just a union of states, and then applies the deferred
+%% operations.
+-spec model_merge(map_model(), map_model()) -> map_model().
 model_merge(Model1, Model2) ->
     #model{adds=Adds1, removes=Removes1, deferred=Deferred1, clock=Clock1, tombstones=TS1} = Model1,
     #model{adds=Adds2, removes=Removes2, deferred=Deferred2, clock=Clock2, tombstones=TS2} = Model2,
     Clock = riak_dt_vclock:merge([Clock1, Clock2]),
-    Adds0 = sets:union(Adds1, Adds2),
+    Adds0 = lists:umerge(Adds1, Adds2),
     Tombstones = orddict:merge(fun({_Name, Type}, V1, V2) -> Type:merge(V1, V2) end, TS1, TS2),
-    Removes0 = sets:union(Removes1, Removes2),
-    Deferred0 = sets:union(Deferred1, Deferred2),
+    Removes0 = lists:umerge(Removes1, Removes2),
+    Deferred0 = lists:umerge(Deferred1, Deferred2),
     {Adds, Removes, Deferred} = model_apply_deferred(Adds0, Removes0, Deferred0),
     #model{adds=Adds, removes=Removes, deferred=Deferred, clock=Clock, tombstones=Tombstones}.
 
+%% @doc apply deferred operations that may be relevant now a merge as taken place.
+-spec model_apply_deferred(list(), list(), list()) -> {list(), list(), list()}.
 model_apply_deferred(Adds, Removes, Deferred) ->
-    D2 = sets:subtract(Deferred, Adds),
-    ToRem = sets:subtract(Deferred, D2),
-    {Adds, sets:union(ToRem, Removes), D2}.
+    D2 = lists:subtract(Deferred, Adds),
+    ToRem = lists:subtract(Deferred, D2),
+    {Adds, lists:umerge(ToRem, Removes), D2}.
 
+%% @doc remove `Field' from `To' using `From's context.
+-spec model_ctx_remove({atom(), module()}, map_model(), map_model()) -> map_model().
 model_ctx_remove({_N, Type}=Field, From, To) ->
     %% get adds for Field, any adds for field in ToAdds that are in
     %% FromAdds should be removed any others, put in deferred
     #model{adds=FromAdds, clock=FromClock} = From,
     #model{adds=ToAdds, removes=ToRemoves, deferred=ToDeferred, tombstones=TS} = To,
-    ToRemove = sets:filter(fun({F, _Val, _Token}) -> F == Field end, FromAdds),
-    Defer = sets:subtract(ToRemove, ToAdds),
-    Remove = sets:subtract(ToRemove, Defer),
+    ToRemove = lists:filter(fun({F, _Val, _Token}) -> F == Field end, FromAdds),
+    Defer = lists:subtract(ToRemove, ToAdds),
+    Remove = lists:subtract(ToRemove, Defer),
     Tombstone = Type:parent_clock(FromClock, Type:new()),
     TS2 = orddict:update(Field, fun(T) -> Type:merge(T, Tombstone) end, Tombstone, TS),
-    To#model{removes=sets:union(Remove, ToRemoves),
-           deferred=sets:union(Defer, ToDeferred),
-            tombstones=TS2}.
+    To#model{removes=lists:umerge(Remove, ToRemoves),
+             deferred=lists:umerge(Defer, ToDeferred),
+             tombstones=TS2}.
 
+%% @doc get the actual value for a model
+-spec model_value(map_model()) ->
+                         [{Field::{atom(), module()}, Value::term()}].
 model_value(Model) ->
     #model{adds=Adds, removes=Removes, tombstones=TS} = Model,
-    Remaining = sets:subtract(Adds, Removes),
+    Remaining = lists:subtract(Adds, Removes),
+    %% fold over fields that are in the map and merge each to a merge
+    %% CRDT per field
     Res = lists:foldl(fun({{_Name, Type}=Key, Value, _X}, Acc) ->
                               %% if key is in Acc merge with it and replace
                               dict:update(Key, fun(V) ->
                                                        Type:merge(V, Value) end,
                                           Value, Acc) end,
                       dict:new(),
-                      sets:to_list(Remaining)),
+                      Remaining),
+    %% fold over merged CRDTs and merge with the tombstone (if any)
+    %% for each field
     Res2 = dict:fold(fun({_N, Type}=Field, Val, Acc) ->
                              case orddict:find(Field, TS) of
                                  error ->
@@ -518,9 +552,13 @@ model_value(Model) ->
                      end,
                      dict:new(),
                      Res),
+    %% Call `value/1' on each CRDT in the model
     [{K, Type:value(V)} || {{_Name, Type}=K, V} <- dict:to_list(Res2)].
 
+%% @doc get a context for a model context operation
+-spec model_ctx(map_model()) -> riak_dt_vclock:vclock().
 model_ctx(#model{clock=Ctx}) ->
     Ctx.
+
 
 -endif. % EQC

--- a/test/od_flag_eqc.erl
+++ b/test/od_flag_eqc.erl
@@ -1,8 +1,8 @@
 %% -------------------------------------------------------------------
 %%
-%% map_eqc: Drive out the merge bugs the other statem couldn't
+%% od_flag_eqc: Drive out the merge bugs the other statem couldn't
 %%
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -28,20 +28,7 @@
 
 -compile(export_all).
 
--type model() :: {Cntr :: pos_integer(), %% Unique ID per operation
-                      Enables :: set(), %% enables
-                      Disable :: set(), %% Tombstones
-                      %% Disable that are waiting for enables before they
-                      %% can be run (like context ops in the
-                      %% riak_dt_od_flag)
-                      Deferred :: set()
-                     }.
-
 -record(state,{replicas=[] :: [binary()], %% Sort of like the ring, upto N*2 ids
-               replica_data=[] :: [{ActorId :: binary(),
-                                    riak_dt_od_flag:od_flag(),
-                                    model()}],
-               n=0 :: pos_integer(), %% Generated number of replicas
                counter=1 :: pos_integer() %% a unique tag per add
               }).
 
@@ -67,187 +54,199 @@ check() ->
 initial_state() ->
     #state{}.
 
-%% ------ Grouped operator: set_nr
-%% Only set N if N has not been set (ie run once, as the first command)
-set_n_pre(#state{n=N}) ->
-     N == 0.
+%% ------ Grouped operator: create_replica
+create_replica_pre(#state{replicas=Replicas}) ->
+    length(Replicas) < 10.
 
-%% Choose how many replicas to have in the system
-set_n_args(_S) ->
-    [choose(2, 10)].
+%% @doc create_replica_command - Command generator
+create_replica_args(_S) ->
+    %% Don't waste time shrinking the replicas ID binaries, they 8
+    %% byte binaris as that is riak-esque.
+    [noshrink(binary(8))].
 
-set_n(_) ->
-    %% Command args used for next state only
-    ok.
+%% @doc create_replica_pre - don't create a replica that already
+%% exists
+-spec create_replica_pre(S :: eqc_statem:symbolic_state(),
+                         Args :: [term()]) -> boolean().
+create_replica_pre(#state{replicas=Replicas}, [Id]) ->
+    not lists:member(Id, Replicas).
 
-set_n_next(S, _V, [N]) ->
-    S#state{n=N}.
+%% @doc create a new replica, and store a bottom orswot/orset+deferred
+%% in ets
+create_replica(Id) ->
+    ets:insert(od_flag_eqc, {Id, riak_dt_od_flag:new(), model_new()}).
 
-%% ------ Grouped operator: make_ring
-%%
-%% Generate a bunch of replicas, only runs if N is set, and until
-%% "enough" are generated (N*2) is more than enough.
-make_ring_pre(#state{replicas=Replicas, n=N}) ->
-    N > 0 andalso length(Replicas) < N * 2.
-
-make_ring_args(#state{replicas=Replicas, n=N}) ->
-    [Replicas, vector(N, binary(8))].
-
-make_ring(_,_) ->
-    %% Command args used for next state only
-    ok.
-
-make_ring_next(S, _V, [Replicas0, NewReplicas]) ->
-    %% No duplicate replica ids please!
-    Replicas = lists:umerge(Replicas0, NewReplicas),
-    S#state{replicas=Replicas}.
+%% @doc create_replica_next - Add the new replica ID to state
+-spec create_replica_next(S :: eqc_statem:symbolic_state(),
+                          V :: eqc_statem:var(),
+                          Args :: [term()]) -> eqc_statem:symbolic_state().
+create_replica_next(S=#state{replicas=R0}, _Value, [Id]) ->
+    S#state{replicas=R0++[Id]}.
 
 %% ------ Grouped operator: enable
 %% enable the flag
-enable_pre(S) ->
-    replicas_ready(S).
+enable_pre(#state{replicas=Replicas}) ->
+    Replicas /= [].
 
-enable_args(#state{replicas=Replicas, replica_data=ReplicaData, counter=Cnt}) ->
+enable_args(#state{replicas=Replicas, counter=Cnt}) ->
     [
      elements(Replicas), % The replica
-     Cnt,
-     ReplicaData %% The existing vnode data
+     Cnt
     ].
 
+enable_pre(#state{replicas=Replicas}, [Replica, _Cnt]) ->
+    lists:member(Replica, Replicas).
 
-enable(Actor, Cnt, ReplicaData) ->
-    {Flag, Model} = get(Actor, ReplicaData),
+enable(Actor, Cnt) ->
+    [{Actor, Flag, Model}] = ets:lookup(od_flag_eqc, Actor),
     {ok, Flag2} = riak_dt_od_flag:update(enable, Actor, Flag),
     {ok, Model2} = model_enable(Cnt, Model),
-    {Actor, Flag2, Model2}.
+    ets:insert(od_flag_eqc, {Actor, Flag2, Model2}),
+    {Flag2, Model2}.
 
-enable_next(S=#state{replica_data=ReplicaData, counter=Cnt}, Res, [_, _, _]) ->
-    S#state{replica_data=[Res | ReplicaData], counter=Cnt+1}.
+enable_next(S=#state{counter=Cnt}, _Res, [_, _]) ->
+    S#state{counter=Cnt+1}.
 
 enable_post(_S, _Args, Res) ->
     post_all(Res, enable).
 
 %% ------ Grouped operator: disable
 
-disable_pre(S=#state{}) ->
-    replicas_ready(S).
+disable_pre(#state{replicas=Replicas}) ->
+    Replicas /= [].
 
-disable_args(#state{replicas=Replicas, replica_data=ReplicaData}) ->
+disable_args(#state{replicas=Replicas}) ->
     [
-     elements(Replicas),
-     ReplicaData %% All the vnode data
+     elements(Replicas)
     ].
 
-disable(Replica, ReplicaData) ->
-    {Flag, Model} = get(Replica, ReplicaData),
+disable_pre(#state{replicas=Replicas}, [Replica]) ->
+    lists:member(Replica, Replicas).
+
+disable(Replica) ->
+    [{Replica, Flag, Model}] = ets:lookup(od_flag_eqc, Replica),
     {ok, Flag2} = riak_dt_od_flag:update(disable, Replica, Flag),
     Model2 = model_disable(Model),
-    {Replica, Flag2, Model2}.
-
-disable_next(S=#state{replica_data=ReplicaData}, Res, [_, _]) ->
-    S#state{replica_data=[Res | ReplicaData]}.
+    ets:insert(od_flag_eqc, {Replica, Flag2, Model2}),
+    {Flag2, Model2}.
 
 disable_post(_S, _Args, Res) ->
     post_all(Res, disable).
 
 %% ------ Grouped operator: ctx_disable
 %% disable, but with a context
-ctx_disable_pre(S=#state{replica_data=ReplicaData}) ->
-    replicas_ready(S) andalso ReplicaData /= [].
+ctx_disable_pre(#state{replicas=Replicas}) ->
+    Replicas /= [].
 
-ctx_disable_args(#state{replicas=Replicas, replica_data=ReplicaData}) ->
+ctx_disable_args(#state{replicas=Replicas}) ->
     [
      elements(Replicas), %% read from
-     elements(Replicas), %% send op too
-     ReplicaData %% All the vnode data
+     elements(Replicas) %% send op too
     ].
 
-%% Should we send ctx ops to originating replica?
-ctx_disable_pre(_S, [VN, VN, _]) ->
-    false;
-ctx_disable_pre(_S, [_VN1, _VN2, _]) ->
-    true.
+%% @doc ctx_disable_pre - Ensure correct shrinking
+-spec ctx_disable_pre(S :: eqc_statem:symbolic_state(),
+                         Args :: [term()]) -> boolean().
+ctx_disable_pre(#state{replicas=Replicas}, [From, To]) ->
+    lists:member(From, Replicas) andalso lists:member(To, Replicas).
 
-ctx_disable(From, To, ReplicaData) ->
-    {FromFlag, FromModel} = get(From, ReplicaData),
-    {ToFlag, ToModel} = get(To, ReplicaData),
+%% @doc a dynamic precondition uses concrete state, check that the
+%% `From' flag is enabled
+ctx_disable_dynamicpre(_S, [From, _To]) ->
+    [{From, Flag, _FromORSet}] = ets:lookup(od_flag_eqc, From),
+    riak_dt_od_flag:value(Flag).
+
+ctx_disable(From, To) ->
+    [{From, FromFlag, FromModel}] = ets:lookup(od_flag_eqc, From),
+    [{To, ToFlag, ToModel}] = ets:lookup(od_flag_eqc, To),
     Ctx = riak_dt_od_flag:precondition_context(FromFlag),
     {ok, Flag} = riak_dt_od_flag:update(disable, To, ToFlag, Ctx),
     Model = model_ctx_disable(FromModel, ToModel),
-    {To, Flag, Model}.
-
-ctx_disable_next(S=#state{replica_data=ReplicaData}, Res, _) ->
-    S#state{replica_data=[Res | ReplicaData]}.
+    ets:insert(od_flag_eqc, {To, Flag, Model}),
+    {Flag, Model}.
 
 ctx_disable_post(_S, _Args, Res) ->
     post_all(Res, ctx_disable).
 
 %% ------ Grouped operator: replicate
 %% Merge two replicas' values
-replicate_pre(S=#state{replica_data=ReplicaData}) ->
-    replicas_ready(S) andalso ReplicaData /= [].
+replicate_pre(#state{replicas=Replicas}) ->
+    Replicas /= [].
 
-replicate_args(#state{replicas=Replicas, replica_data=ReplicaData}) ->
+replicate_args(#state{replicas=Replicas}) ->
     [
      elements(Replicas), %% Replicate from
-     elements(Replicas), %% Replicate to
-     ReplicaData
+     elements(Replicas) %% Replicate to
     ].
 
-%% Don't replicate to oneself
-replicate_pre(_S, [VN, VN, _]) ->
-    false;
-replicate_pre(_S, [_VN1, _VN2, _]) ->
-    true.
+%% @doc replicate_pre - Ensure correct shrinking
+-spec replicate_pre(S :: eqc_statem:symbolic_state(),
+                    Args :: [term()]) -> boolean().
+replicate_pre(#state{replicas=Replicas}, [From, To]) ->
+    lists:member(From, Replicas) andalso lists:member(To, Replicas).
 
 %% Replicate a CRDT from `From' to `To'
-replicate(From, To, ReplicaData) ->
-    {FromFlag, FromModel} = get(From, ReplicaData),
-    {ToFlag, ToModel} = get(To, ReplicaData),
+replicate(From, To) ->
+    [{From, FromFlag, FromModel}] = ets:lookup(od_flag_eqc, From),
+    [{To, ToFlag, ToModel}] = ets:lookup(od_flag_eqc, To),
     Flag = riak_dt_od_flag:merge(FromFlag, ToFlag),
     Model = model_merge(FromModel, ToModel),
-    {To, Flag, Model}.
-
-replicate_next(S=#state{replica_data=ReplicaData}, Res, _Args) ->
-    S#state{replica_data=[Res | ReplicaData]}.
+    ets:insert(od_flag_eqc, {To, Flag, Model}),
+    {Flag, Model}.
 
 replicate_post(_S, _Args, Res) ->
     post_all(Res, rep).
 
+%% @doc weights for commands. Don't create too many replicas, but
+%% prejudice in favour of creating more than 1. Try and balance
+%% disable with enables. But favour enables so we have something to
+%% disable. See the aggregation output.
+weight(S, create_replica) when length(S#state.replicas) > 2 ->
+    1;
+weight(S, create_replica) when length(S#state.replicas) < 5 ->
+    4;
+weight(_S, disable) ->
+    3;
+weight(_S, ctx_disable) ->
+    3;
+weight(_S, enable) ->
+    6;
+weight(_S, _) ->
+    2.
 
 %% Tests the property that an od_flag is equivalent to the flag model
 prop_merge() ->
     ?FORALL(Cmds, commands(?MODULE),
             begin
-                {H, S=#state{replicas=Replicas, replica_data=ReplicaData}, Res} = run_commands(?MODULE,Cmds),
+                %% Store the state external to the statem for correct
+                %% shrinking. This is best practice.
+                ets:new(od_flag_eqc, [named_table, set]),
+                {H, S, Res} = run_commands(?MODULE,Cmds),
+                ReplicaData =               ets:tab2list(od_flag_eqc),
                 %% Check that collapsing all values leads to the same results for flag and the Model
-                {FlagValue, ModelValue} = case Replicas of
-                                             [] ->
-                                                 {[], []};
-                                             _L ->
-                                                 %% Get ALL actor's values
-                                                 {Flag, Model} = lists:foldl(fun(Actor, {F, Mo}) ->
-                                                                                    {F1, Mo1} = get(Actor, ReplicaData),
-                                                                                    {riak_dt_od_flag:merge(F, F1),
-                                                                                     model_merge(Mo, Mo1)} end,
-                                                                            {riak_dt_od_flag:new(), model_new()},
-                                                                            Replicas),
-                                                 {riak_dt_od_flag:value(Flag), model_value(Model)}
-                                         end,
+                {Flag, Model} = lists:foldl(fun({_Actor, F1, Mo1}, {F, Mo}) ->
+                                                    {riak_dt_od_flag:merge(F, F1),
+                                                     model_merge(Mo, Mo1)} end,
+                                            {riak_dt_od_flag:new(), model_new()},
+                                            ReplicaData),
+
+                {FlagValue, ModelValue} = {riak_dt_od_flag:value(Flag), model_value(Model)},
+
+                ets:delete(od_flag_eqc),
+
                 aggregate(command_names(Cmds),
                           pretty_commands(?MODULE,Cmds, {H,S,Res},
-                                          conjunction([{result,  equals(Res, ok)},
-                                                       {values, equals(FlagValue, ModelValue)}])
-                                         ))
+                                          collect(with_title(value), FlagValue,
+                                                    measure(replicas, length(ReplicaData),
+                                                            conjunction([{result,  equals(Res, ok)},
+                                                                         {values, equals(FlagValue, ModelValue)}])
+                                                           ))))
             end).
 
 %% -----------
 %% Helpers
 %% ----------
-replicas_ready(#state{replicas=Replicas, n=N}) ->
-    length(Replicas) >= N andalso N > 0.
-
-post_all({_, Flag, Model}, Cmd) ->
+post_all({Flag, Model}, Cmd) ->
     %% What matters is that both types have the exact same value.
     case riak_dt_od_flag:value(Flag) == model_value(Model) of
         true ->
@@ -256,47 +255,49 @@ post_all({_, Flag, Model}, Cmd) ->
             {postcondition_failed, "Flag and Model don't match", Cmd, Flag, Model}
     end.
 
-%% if a replica does not yet have replica data, return `new()` for the
-%% Map and Model
-get(Replica, ReplicaData) ->
-    case lists:keyfind(Replica, 1, ReplicaData) of
-        {Replica, Map, Model} ->
-            {Map, Model};
-        false -> {riak_dt_od_flag:new(), model_new()}
-    end.
-
 %% -----------
 %% Model
 %% ----------
+
+-type model() :: {Cntr :: pos_integer(), %% Unique ID per operation
+                      Enables :: list(), %% enables
+                      Disable :: list(), %% Tombstones
+                      %% Disable that are waiting for enables before they
+                      %% can be run (like context ops in the
+                      %% riak_dt_od_flag)
+                      Deferred :: list()
+                     }.
+
+-spec model_new() -> model().
 model_new() ->
-    {sets:new(), sets:new(), sets:new()}.
+    {[], [], []}.
 
 model_enable(Cnt, {Enables, Disables, Deferred}) ->
-    {ok, {sets:add_element(Cnt, Enables), Disables, Deferred}}.
+    {ok, {lists:umerge([Cnt], Enables), Disables, Deferred}}.
 
 model_disable({Enables, Disables, Deferred}) ->
-    {Enables, sets:union(Disables, Enables), Deferred}.
+    {Enables, lists:merge(Disables, Enables), Deferred}.
 
 model_merge({Enables1, Disables1, Deferred1}, {Enables2, Disables2, Deferred2}) ->
-    Enables = sets:union(Enables1, Enables2),
-    Disables = sets:union(Disables1, Disables2),
-    Deferred = sets:union(Deferred1, Deferred2),
+    Enables = lists:umerge(Enables1, Enables2),
+    Disables = lists:umerge(Disables1, Disables2),
+    Deferred = lists:umerge(Deferred1, Deferred2),
     model_apply_deferred(Enables, Disables, Deferred).
 
 model_apply_deferred(Enables, Disables, Deferred) ->
-    D2 = sets:subtract(Deferred, Enables),
-    Dis = sets:subtract(Deferred, D2),
-    {Enables, sets:union(Dis, Disables), D2}.
+    D2 = lists:subtract(Deferred, Enables),
+    Dis = lists:subtract(Deferred, D2),
+    {Enables, lists:umerge(Dis, Disables), D2}.
 
 model_ctx_disable({FromEnables, _FromDisables, _FromDeferred}, {ToEnables, ToDisables, ToDeferred}) ->
     %% Disable enables that are in both
-    Disable = sets:intersection(FromEnables, ToEnables),
+    Disable = sets:to_list(sets:intersection(sets:from_list(FromEnables), sets:from_list(ToEnables))),
     %% Defer those enables not seen in target
-    Defer = sets:subtract(FromEnables, ToEnables),
-    {ToEnables, sets:union(ToDisables, Disable), sets:union(Defer, ToDeferred)}.
+    Defer = lists:subtract(FromEnables, ToEnables),
+    {ToEnables, lists:umerge(ToDisables, Disable), lists:umerge(Defer, ToDeferred)}.
 
 model_value({Enables, Disables, _Deferred}) ->
-    Remaining = sets:subtract(Enables, Disables),
-    sets:size(Remaining) > 0.
+    Remaining = lists:subtract(Enables, Disables),
+    length(Remaining) > 0.
 
 -endif. % EQC

--- a/test/od_flag_eqc.erl
+++ b/test/od_flag_eqc.erl
@@ -97,10 +97,10 @@ make_ring(_,_) ->
     %% Command args used for next state only
     ok.
 
-make_ring_next(S=#state{replicas=Replicas}, _V, [_, NewReplicas0]) ->
+make_ring_next(S, _V, [Replicas0, NewReplicas]) ->
     %% No duplicate replica ids please!
-    NewReplicas = lists:filter(fun(Id) -> not lists:member(Id, Replicas) end, NewReplicas0),
-    S#state{replicas=Replicas ++ NewReplicas}.
+    Replicas = lists:umerge(Replicas0, NewReplicas),
+    S#state{replicas=Replicas}.
 
 %% ------ Grouped operator: enable
 %% enable the flag

--- a/test/orswot_eqc.erl
+++ b/test/orswot_eqc.erl
@@ -2,8 +2,7 @@
 %%
 %% orswot_eqc: Try and catch bugs crdt_statem could not.
 %%
-%% TODO DVV disabled? Get, interleave writes, Put
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -22,30 +21,18 @@
 
 -module(orswot_eqc).
 
--ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -compile(export_all).
 
--record(state,{replicas=[] :: [binary()], %% Sort of like the ring, upto N*2 ids
-               replica_data=[] :: [{ActorId :: binary(),
-                                  riak_dt_orswot:orswot(),
-                                  model()}],
-               %% The data, duplicated values for replicas
-               %% Newest at the head of the list.
-               %% Prepend only data 'cos symbolic / dynamic state.
-               n=0 :: integer(), %% Generated number of replicas
-               adds=[] :: [{ActorId :: binary(), atom()}] %% things that have been added
-              }).
+-record(state, {replicas=[], %% Actor Ids for replicas in the system
+                adds=[]      %% Elements that have been added to the set
+               }).
 
--type model() :: {riak_dt_orset:orset(), deferred()}.
-%% orset remove entries that cannot be added to an orset yet, as the
-%% add entry is unseen. A way of modelling the context operations of
-%% orswot, without adding the same thing to the ORSet implementation
-%% (where it has no real meaning)
--type deferred() :: riak_dt_orset:orset().
+%% The set of possible elements in the set
+-define(ELEMENTS, ['A', 'B', 'C', 'D', 'X', 'Y', 'Z']).
 
 -define(NUMTESTS, 1000).
 -define(QC_OUT(P),
@@ -64,97 +51,242 @@ run(Count) ->
 check() ->
     eqc:check(prop_merge()).
 
-%% Initialize the state
--spec initial_state() -> eqc_statem:symbolic_state().
+
 initial_state() ->
     #state{}.
 
+%% ------ Grouped operator: create_replica
+create_replica_pre(#state{replicas=Replicas}) ->
+    length(Replicas) < 10.
 
-%% ------ Grouped operator: set_nr
-%% Only set N if N has not been set (ie run once, as the first command)
-set_nr_pre(#state{n=N}) ->
-     N == 0.
+%% @doc create_replica_command - Command generator
+create_replica_args(_S) ->
+    %% Don't waste time shrinking the replicas ID binaries, they 8
+    %% byte binaris as that is riak-esque.
+    [noshrink(binary(8))].
 
-set_nr_args(_S) ->
-    [choose(2, 10)].
+%% @doc create_replica_pre - don't create a replica that already
+%% exists
+-spec create_replica_pre(S :: eqc_statem:symbolic_state(),
+                         Args :: [term()]) -> boolean().
+create_replica_pre(#state{replicas=Replicas}, [Id]) ->
+    not lists:member(Id, Replicas).
 
-set_nr(_) ->
-    %% Command args used for next state only
-    ok.
+%% @doc create a new replica, and store a bottom orswot/orset+deferred
+%% in ets
+create_replica(Id) ->
+    ets:insert(orswot_eqc, {Id, riak_dt_orswot:new(), {riak_dt_orset:new(), riak_dt_orset:new()}}).
 
-set_nr_next(S, _V, [N]) ->
-    S#state{n=N}.
-
-%% ------ Grouped operator: make_ring
-%% Generate a bunch of replicas,
-%% only runs until enough are generated
-make_ring_pre(#state{replicas=Replicas, n=N}) ->
-    N > 0 andalso length(Replicas) < N * 2.
-
-make_ring_args(#state{replicas=Replicas, n=N}) ->
-    [Replicas, vector(N, binary(8))].
-
-make_ring(_,_) ->
-    %% Command args used for next state only
-    ok.
-
-make_ring_next(S, _V, [Replicas, NewReplicas0]) ->
-    %% No duplicate replica ids please!
-    R1 = lists:umerge(Replicas, NewReplicas0),
-    S#state{replicas=R1}.
+%% @doc create_replica_next - Add the new replica ID to state
+-spec create_replica_next(S :: eqc_statem:symbolic_state(),
+                          V :: eqc_statem:var(),
+                          Args :: [term()]) -> eqc_statem:symbolic_state().
+create_replica_next(S=#state{replicas=R0}, _Value, [Id]) ->
+    S#state{replicas=R0++[Id]}.
 
 %% ------ Grouped operator: add
-%% Store a new value
-add_pre(S) ->
-    replicas_ready(S).
+add_args(#state{replicas=Replicas}) ->
+    [elements(Replicas),
+     %% Start of with earlier/fewer elements
+     growingelements(?ELEMENTS)].
 
-add_args(#state{replicas=Replicas, replica_data=ReplicaData}) ->
-    [
-     oneof(['X', 'Y', 'Z']), %% a new value
-     elements(Replicas), % The replica
-     ReplicaData %% The existing replica data
-    ].
+%% @doc add_pre - Don't add to a set until we have a replica
+-spec add_pre(S :: eqc_statem:symbolic_state()) -> boolean().
+add_pre(#state{replicas=Replicas}) ->
+    Replicas /= [].
 
-%% Add a value to the set
-add(Value, Actor, ReplicaData) ->
-    {ORSWOT, {ORSet, Deferred}} = get(Actor, ReplicaData),
-    {ok, ORSWOT2} = riak_dt_orswot:update({add, Value}, Actor, ORSWOT),
-    {ok, ORSet2} = riak_dt_orset:update({add, Value}, Actor, ORSet),
-    {Actor, ORSWOT2, {ORSet2, Deferred}}.
+%% @doc add_pre - Ensure correct shrinking, only select a replica that
+%% is in the state
+-spec add_pre(S :: eqc_statem:symbolic_state(),
+              Args :: [term()]) -> boolean().
+add_pre(#state{replicas=Replicas}, [Replica, _]) ->
+    lists:member(Replica, Replicas).
 
-add_next(S=#state{replica_data=ReplicaData, adds=Adds}, Res, [Value, Coord, _]) ->
-    %% The state data is prepend only, it grows and grows, but it's based on older state
-    %% Newest at the front.
-    S#state{replica_data=[Res | ReplicaData], adds=[{Coord, Value} | Adds]}.
+%% @doc add the `Element' to the sets at `Replica'
+add(Replica, Element) ->
+    [{Replica, ORSWOT, {ORSet, Def}}] = ets:lookup(orswot_eqc, Replica),
+    {ok, ORSWOT2} = riak_dt_orswot:update({add, Element}, Replica, ORSWOT),
+    {ok, ORSet2} = riak_dt_orset:update({add, Element}, Replica, ORSet),
+    ets:insert(orswot_eqc, {Replica, ORSWOT2, {ORSet2, Def}}),
+    {ORSWOT2, ORSet2}.
 
-add_post(_S, _Args, Res) ->
-    post_all(Res, add).
+%% @doc add_next - Add the `Element' to the `adds' list so we can
+%% select from it when we come to remove. This increases the liklihood
+%% of a remove actuallybeing meaningful.
+-spec add_next(S :: eqc_statem:symbolic_state(),
+               V :: eqc_statem:var(),
+               Args :: [term()]) -> eqc_statem:symbolic_state().
+add_next(S=#state{adds=Adds}, _Value, [_, Element]) ->
+    S#state{adds=lists:umerge(Adds, [Element])}.
+
+%% @doc add_post - The specification and implementation should be
+%% equal in intermediate states as well as at the end.
+-spec add_post(S :: eqc_statem:dynamic_state(),
+               Args :: [term()], R :: term()) -> true | term().
+add_post(_S, _Args, {ORSWOT, ORSet}) ->
+    sets_equal(ORSWOT, ORSet).
 
 %% ------ Grouped operator: remove
-%% remove, but only something that has been added already
-remove_pre(S=#state{adds=Adds}) ->
-    %% Only do an update if you already did a get
-    replicas_ready(S) andalso Adds /= [].
+%% @doc remove_command - Command generator
 
-remove_args(#state{adds=Adds, replica_data=ReplicaData}) ->
-    [
-     elements(Adds), %% Something that has been added
-     ReplicaData %% All the vnode data
-    ].
+%% @doc remove_pre - Only remove if there are replicas and elements
+%% added already.
+-spec remove_pre(S :: eqc_statem:symbolic_state()) -> boolean().
+remove_pre(#state{replicas=Replicas, adds=Adds}) ->
+    Replicas /= [] andalso Adds /= [].
 
-remove_pre(#state{adds=Adds}, [Add, _]) ->
-    lists:member(Add, Adds).
+remove_args(#state{replicas=Replicas, adds=Adds}) ->
+    [elements(Replicas), elements(Adds)].
 
-remove({Replica, Value}, ReplicaData) ->
-    {ORSWOT, {ORSet, Deferred}} = get(Replica, ReplicaData),
+%% @doc ensure correct shrinking
+remove_pre(#state{replicas=Replicas}, [Replica, _]) ->
+    lists:member(Replica, Replicas).
+
+%% @doc perform an element remove.
+remove(Replica, Value) ->
+    [{Replica, ORSWOT, {ORSet, Def}}] = ets:lookup(orswot_eqc, Replica),
     %% even though we only remove what has been added, there is no
     %% guarantee a merge from another replica hasn't led to the
     %% element being removed already, so ignore precon errors (they
     %% don't change state)
-    ORSWOT2 = ignore_preconerror_remove(Value, ReplicaData, ORSWOT, riak_dt_orswot),
-    ORSet2 = ignore_preconerror_remove(Value, ReplicaData, ORSet, riak_dt_orset),
-    {Replica, ORSWOT2, {ORSet2, Deferred}}.
+    ORSWOT2 = ignore_preconerror_remove(Value, Replica, ORSWOT, riak_dt_orswot),
+    ORSet2 = ignore_preconerror_remove(Value, Replica, ORSet, riak_dt_orset),
+    ets:insert(orswot_eqc, {Replica, ORSWOT2, {ORSet2, Def}}),
+    {ORSWOT2, ORSet2}.
 
+%% @doc in a non-context remove, not only must the spec and impl be
+%% equal, but the `Element' MUST be absent from the set
+remove_post(_S, [_, Element], {ORSWOT2, ORSet2}) ->
+    eqc_statem:conj([sets_not_member(Element, ORSWOT2),
+          sets_equal(ORSWOT2, ORSet2)]).
+
+%% ------ Grouped operator: replicate
+%% @doc replicate_args - Choose a From and To for replication
+replicate_args(#state{replicas=Replicas}) ->
+    [elements(Replicas), elements(Replicas)].
+
+%% @doc replicate_pre - There must be at least on replica to replicate
+-spec replicate_pre(S :: eqc_statem:symbolic_state()) -> boolean().
+replicate_pre(#state{replicas=Replicas}) ->
+    Replicas /= [].
+
+%% @doc replicate_pre - Ensure correct shrinking
+-spec replicate_pre(S :: eqc_statem:symbolic_state(),
+                    Args :: [term()]) -> boolean().
+replicate_pre(#state{replicas=Replicas}, [From, To]) ->
+    lists:member(From, Replicas) andalso lists:member(To, Replicas).
+
+%% @doc simulate replication by merging state at `To' with state from `From'
+replicate(From, To) ->
+    [{From, FromORSWOT, {FromORSet, FromDef}}] = ets:lookup(orswot_eqc, From),
+    [{To, ToORSWOT, {ToORSet, ToDef}}] = ets:lookup(orswot_eqc, To),
+
+    ORSWOT = riak_dt_orswot:merge(FromORSWOT, ToORSWOT),
+    ORSet0 = riak_dt_orset:merge(FromORSet, ToORSet),
+    Def0 = riak_dt_orset:merge(FromDef, ToDef),
+
+    {ORSet, Def} = model_apply_deferred(ORSet0, Def0),
+
+    ets:insert(orswot_eqc, {To, ORSWOT, {ORSet, Def}}),
+    {ORSWOT, ORSet}.
+
+%% @doc replicate_post - ORSet and ORSWOT must be equal throughout.
+-spec replicate_post(S :: eqc_statem:dynamic_state(),
+                     Args :: [term()], R :: term()) -> true | term().
+replicate_post(_S, [_From, _To], {SWOT, Set}) ->
+    sets_equal(SWOT, Set).
+
+
+%% ------ Grouped operator: context_remove
+context_remove_args(#state{replicas=Replicas, adds=Adds}) ->
+    [elements(Replicas),
+     elements(Replicas),
+     elements(Adds)].
+
+%% @doc context_remove_pre - As for `remove/1'
+-spec context_remove_pre(S :: eqc_statem:symbolic_state()) -> boolean().
+context_remove_pre(#state{replicas=Replicas, adds=Adds}) ->
+    Replicas /= [] andalso Adds /= [].
+
+%% @doc context_remove_pre - Ensure correct shrinking
+-spec context_remove_pre(S :: eqc_statem:symbolic_state(),
+                         Args :: [term()]) -> boolean().
+context_remove_pre(#state{replicas=Replicas, adds=Adds}, [From, To, Element]) ->
+    lists:member(From, Replicas) andalso lists:member(To, Replicas)
+        andalso lists:member(Element, Adds).
+
+%% @doc a dynamic precondition uses concrete state, check that the
+%% `From' set contains `Element'
+context_remove_dynamicpre(_S, [From, _To, Element]) ->
+    [{From, SWOT, _FromORSet}] = ets:lookup(orswot_eqc, From),
+    lists:member(Element, riak_dt_orswot:value(SWOT)).
+
+%% @doc perform a context remove using the context+element at `From'
+%% and removing from `To'
+context_remove(From, To, Element) ->
+    [{From, FromORSWOT, {FromORSet, _FromDef}}] = ets:lookup(orswot_eqc, From),
+    [{To, ToORSWOT, {ToORSet, ToDef}}] = ets:lookup(orswot_eqc, To),
+
+    Ctx = riak_dt_orswot:precondition_context(FromORSWOT),
+    Fragment = riak_dt_orset:value({fragment, Element}, FromORSet),
+    {ok, ToORSWOT2} = riak_dt_orswot:update({remove, Element}, To, ToORSWOT, Ctx),
+
+    {ToORSet2, ToDef2} = context_remove_model(Element, Fragment, ToORSet, ToDef),
+
+    ets:insert(orswot_eqc, {To, ToORSWOT2, {ToORSet2, ToDef2}}),
+    {ToORSWOT2, ToORSet2}.
+
+%% @doc weights for commands. Don't create too many replicas, but
+%% prejudice in favour of creating more than 1. Try and balance
+%% removes with adds. But favour adds so we have something to
+%% remove. See the aggregation output.
+weight(S, create_replica) when length(S#state.replicas) > 2 ->
+    1;
+weight(S, create_replica) when length(S#state.replicas) < 5 ->
+    4;
+weight(_S, remove) ->
+    3;
+weight(_S, context_remove) ->
+    3;
+weight(_S, add) ->
+    8;
+weight(_S, _) ->
+    1.
+
+%% @doc check that the implementation of the ORSWOT is equivalent to
+%% the OR-Set impl.
+-spec prop_merge() -> eqc:property().
+prop_merge() ->
+    ?FORALL(Cmds, commands(?MODULE),
+            begin
+                %% Store the state external to the statem for correct
+                %% shrinking. This is best practice.
+                ets:new(orswot_eqc, [named_table, set]),
+                {H, S, Res} = run_commands(?MODULE,Cmds),
+                {MergedSwot, {MergedSet, ModelDeferred}} = lists:foldl(fun({_Id, ORSWOT, ORSetAndDef}, {MO, MOS}) ->
+                                                                               {riak_dt_orswot:merge(ORSWOT, MO),
+                                                                                model_merge(MOS, ORSetAndDef)}
+                                                                       end,
+                                                                       {riak_dt_orswot:new(), {riak_dt_orset:new(), riak_dt_orset:new()}},
+                                                                       ets:tab2list(orswot_eqc)),
+                SwotDeferred = proplists:get_value(deferred_length, riak_dt_orswot:stats(MergedSwot)),
+
+                ets:delete(orswot_eqc),
+                pretty_commands(?MODULE, Cmds, {H, S, Res},
+                                aggregate(command_names(Cmds),
+                                          measure(replicas, length(S#state.replicas),
+                                                  measure(elements, riak_dt_orswot:stat(element_count, MergedSwot),
+                                                          conjunction([{result, Res == ok},
+                                                                       {equal, sets_equal(MergedSwot, MergedSet)},
+                                                                       {m_ec, equals(length(ModelDeferred), 0)},
+                                                                       {ec, equals(SwotDeferred, 0)}
+                                                                      ])))))
+
+            end).
+
+%% Helpers @doc a non-context remove of an absent element generates a
+%% precondition error, but does not mutate the state, so just ignore
+%% and return original state.
 ignore_preconerror_remove(Value, Actor, Set, Mod) ->
     case Mod:update({remove, Value}, Actor, Set) of
         {ok, Set2} ->
@@ -163,46 +295,30 @@ ignore_preconerror_remove(Value, Actor, Set, Mod) ->
             Set
     end.
 
-remove_next(S=#state{replica_data=ReplicaData, adds=Adds}, Res, [Add, _]) ->
-    S#state{replica_data=[Res | ReplicaData], adds=lists:delete(Add, Adds)}.
+%% @doc common precondition and property, do SWOT and Set have the
+%% same elements?
+sets_equal(ORSWOT, ORSet) ->
+    %% What matters is that both types have the exact same results.
+    case lists:sort(riak_dt_orswot:value(ORSWOT)) ==
+        lists:sort(riak_dt_orset:value(ORSet)) of
+        true ->
+            true;
+        _ ->
+            {ORSWOT, '/=', ORSet}
+    end.
 
-remove_post(_S, _Args, Res) ->
-    post_all(Res, remove).
+%% @doc `true' if `Element' is not in `ORSWOT', error tuple otherwise.
+sets_not_member(Element, ORSWOT) ->
+    case lists:member(Element, riak_dt_orswot:value(ORSWOT)) of
+        false ->
+            true;
+        _ ->
+            {Element, member, ORSWOT}
+    end.
 
-%% ------ Grouped operator: replicate
-%% Merge two replicas' values
-replicate_pre(S=#state{replica_data=ReplicaData}) ->
-    replicas_ready(S) andalso ReplicaData /= [].
-
-replicate_args(#state{replicas=Replicas, replica_data=ReplicaData}) ->
-    [
-     elements(Replicas), %% Replicate from
-     elements(Replicas), %% replicate too
-     ReplicaData
-    ].
-
-%% Don't replicate to oneself
-replicate_pre(_S, [VN, VN, _]) ->
-    false;
-replicate_pre(_S, [_VN1, _VN2, _]) ->
-    true.
-
-%% Mutating multiple elements in replica_data in place is bad idea
-%% (symbolic vs dynamic state), so instead of treating add/remove and
-%% replicate as the same action, this command handles the replicate
-%% part. Data from some random replica (From) is replicated to some
-%% random replica (To)
-replicate(From, To, ReplicaData) ->
-    {FromORSWOT, {FromORSet, FromDeferred}} = get(From, ReplicaData),
-    {ToORSWOT, {ToORSet, ToDeferred}} = get(To, ReplicaData),
-    ORSWOT = riak_dt_orswot:merge(FromORSWOT, ToORSWOT),
-    ORSet0 = riak_dt_orset:merge(FromORSet, ToORSet),
-    Deferred0 = riak_dt_orset:merge(FromDeferred, ToDeferred),
-    {ORSet, Deferred} = model_apply_deferred(ORSet0, Deferred0),
-    {To, ORSWOT, {ORSet, Deferred}}.
-
-%% After merging the sets and the deferred list, see if any deferred
-%% removes are now relevant
+%% @doc Since OR-Set does not support deferred operations (yet!) After
+%% merging the sets and the deferred list, see if any deferred removes
+%% are now relevant.
 model_apply_deferred(ORSet, Deferred) ->
     Elems = riak_dt_orset:value(removed, Deferred),
     lists:foldl(fun(E, {OIn, DIn}) ->
@@ -214,64 +330,8 @@ model_apply_deferred(ORSet, Deferred) ->
                 {ORSet, riak_dt_orset:new()},
                 Elems).
 
-replicate_next(S=#state{replica_data=ReplicaData}, Res, _Args) ->
-    S#state{replica_data=[Res | ReplicaData]}.
-
-replicate_post(_S, _Args, Res) ->
-    post_all(Res, rep).
-
-%% ------ Grouped operator: context_remove
-%% Removal operation with a context
-context_remove_pre(S=#state{replica_data=ReplicaData}) ->
-    replicas_ready(S) andalso ReplicaData /= [].
-
-context_remove_args(#state{replicas=Replicas, replica_data=ReplicaData}) ->
-    [
-     elements(Replicas), %% read from
-     elements(Replicas), %% send op too
-     ReplicaData
-    ].
-
-%% Don't send ctx ops to oneself
-context_remove_pre(_S, [VN, VN, _]) ->
-    false;
-context_remove_pre(_S, [_VN1, _VN2, _]) ->
-    true.
-
-%% checks that a context remove is equivalent to performing a remove
-%% on some state and merging it with some other state (eventually) For
-%% the model we chose an element, and send it, them remove it, from
-%% the target replica (like a partial merge.) If we did a full merge
-%% post conditions would not hold.
-context_remove(From, To, ReplicaData) ->
-    {FromORSWOT, {FromORSet, FromDeferred}} = get(From, ReplicaData),
-    {ToORSWOT, {ToORSet, ToDeferred}} = get(To, ReplicaData),
-    case choose_element(FromORSWOT, FromORSet) of
-        empty ->
-            %% No-op
-            {From, FromORSWOT, {FromORSet, FromDeferred}};
-        {{Ctx, Element}, Fragment} ->
-            {ok, ORSWOT} = riak_dt_orswot:update({remove, Element}, To, ToORSWOT, Ctx),
-            {ORSet, Deferred} = context_remove_model(Element, Fragment, ToORSet, ToDeferred),
-            {To, ORSWOT, {ORSet, Deferred}}
-    end.
-
-%% Don't know how to make this a quickcheck generated thing
-choose_element(ORSWOT, ORSet) ->
-    Elems = riak_dt_orswot:value(ORSWOT),
-    %% any element in ORSWOT must be ORSet (see post conditions)
-    case Elems of
-        [] ->
-            empty;
-        _->
-            Elem = lists:nth(crypto:rand_uniform(1, length(Elems) + 1), Elems),
-            Ctx = riak_dt_orswot:precondition_context(ORSWOT),
-            Fragment = riak_dt_orset:value({fragment, Elem}, ORSet),
-            {{Ctx, Elem}, Fragment}
-    end.
-
-%% @TODO Knows about the internal working of riak_dt_orset, maybe
-%% model should be a re-impl of that module instead. Also, this is
+%% @TODO Knows about the internal working of riak_dt_orset,
+%% riak_dt_osret should provide deferred operations. Also, this is
 %% heinously ugly and hard to read.
 context_remove_model(Elem, RemoveContext, ORSet, Deferred) ->
     Present = riak_dt_orset:value({tokens, Elem}, ORSet),
@@ -301,73 +361,13 @@ context_remove_model(Elem, RemoveContext, ORSet, Deferred) ->
                                                  orddict:store(Token, true, orddict:new()),
                                                  Defer)}
                          end
+
                  end,
                  {ORSet, Deferred},
                  Removing).
 
-context_remove_next(S=#state{replica_data=ReplicaData}, Res, _Args) ->
-    S#state{replica_data=[Res | ReplicaData]}.
-
-context_remove_post(_S, _Args, Res) ->
-    post_all(Res, ctx_rem).
-
-%% Tests the property that an ORSWOT is equivalent to an ORSet
-prop_merge() ->
-    ?FORALL(Cmds, commands(?MODULE),
-            begin
-                {H, S=#state{replicas=Replicas, replica_data=ReplicaData}, Res} = run_commands(?MODULE,Cmds),
-                %% Check that collapsing all values leads to the same results for ORSWOT and ORSet
-                {{OV, DeferredLength}, {ORV, Def}} = case Replicas of
-                                                         [] ->
-                                                             {{[], 0}, {[], []}};
-                                                         _L ->
-                                                             %% Get ALL actor's values
-                                                             {OS, {ORSet, Deferred}} = lists:foldl(fun(Actor, {O, {OR, D}}) ->
-                                                                                                 {O1, {OR1, D1}} = get(Actor, ReplicaData),
-                                                                                                 {riak_dt_orswot:merge(O, O1),
-                                                                                                  model_merge({OR, D}, {OR1, D1})} end,
-                                                                                         {riak_dt_orswot:new(), {riak_dt_orset:new(), riak_dt_orset:new()}},
-                                                                                         Replicas),
-                                                             DL = proplists:get_value(deferred_length, riak_dt_orswot:stats(OS)),
-                                                             {{riak_dt_orswot:value(OS), DL}, {riak_dt_orset:value(ORSet), Deferred}}
-                                                     end,
-                aggregate(command_names(Cmds),
-                          pretty_commands(?MODULE,Cmds, {H,S,Res},
-                                          conjunction([{result,  equals(Res, ok)},
-                                                       {values, equals(lists:sort(OV), lists:sort(ORV))},
-                                                       {m_ec, equals(length(Def), 0)},
-                                                       {ec, equals(DeferredLength, 0)}])
-                                         ))
-            end).
-
-%% -----------
-%% Helpers
-%% ----------
+%% @doc merge both orset and deferred operations
 model_merge({S1, D1}, {S2, D2}) ->
     S = riak_dt_orset:merge(S1, S2),
     D = riak_dt_orset:merge(D1, D2),
     model_apply_deferred(S, D).
-
-replicas_ready(#state{replicas=Replicas, n=N}) ->
-    length(Replicas) >= N andalso N > 0.
-
-post_all({_, ORSWOT, {ORSet, _D}}, Cmd) ->
-    %% What matters is that both types have the exact same results.
-    case lists:sort(riak_dt_orswot:value(ORSWOT)) == lists:sort(riak_dt_orset:value(ORSet)) of
-        true ->
-            true;
-        _ ->
-            {postcondition_failed, "SWOT and Set don't match", Cmd, ORSWOT, ORSet}
-    end.
-
-
-%% if a replica does not yet have replica data, return `new()` for the
-%% ORSWOT and ORSet
-get(Replica, ReplicaData) ->
-    case lists:keyfind(Replica, 1, ReplicaData) of
-        {Replica, ORSWOT, ORSet} ->
-            {ORSWOT, ORSet};
-        false -> {riak_dt_orswot:new(), {riak_dt_orset:new(), riak_dt_orset:new()}}
-    end.
-
--endif. % EQC

--- a/test/orswot_eqc.erl
+++ b/test/orswot_eqc.erl
@@ -98,10 +98,10 @@ make_ring(_,_) ->
     %% Command args used for next state only
     ok.
 
-make_ring_next(S=#state{replicas=Replicas}, _V, [_, NewReplicas0]) ->
+make_ring_next(S, _V, [Replicas, NewReplicas0]) ->
     %% No duplicate replica ids please!
-    NewReplicas = lists:filter(fun(Id) -> not lists:member(Id, Replicas) end, NewReplicas0),
-    S#state{replicas=Replicas ++ NewReplicas}.
+    R1 = lists:umerge(Replicas, NewReplicas0),
+    S#state{replicas=R1}.
 
 %% ------ Grouped operator: add
 %% Store a new value


### PR DESCRIPTION
With a shared causal context for the map and the CRDTs it embeds, removing a field, and then re-adding it has the effect of removing all the additions to that field when merging with a concurrent update to the field. For example:

```
Add 'X' to set in field F at A
Merge with B
Add 'Y' to set in field F at B
remove field F at A
Add 'Z' to field F at A
merge A and B
```

The set contains only 'Y' and 'Z', since the remove of the field at A containing 'X' constitutes a remove of 'X'.

However, if the field was _not_ re-added by A the semantic was different, and the result would contain 'X, Y, Z'. This seemed counter-intuitive and confusing. These changes add a temporary tombstone to present fields, so that the removal of a field effects a removal of all dots seen by the field at removal time. But you don't have to re-add the field to see this effect. Neat.

One intuitive way to think of it as like an offline sync of a file system like Dropbox. With this semantic, removing a directory on one machine, and adding a file to that directory on another, merges to the directory being present, with only the added file in it.

There is some oddness with counters, though.

I added a new counter type, `riak_dt_emcntr` (see it's docs for more details) that stores a `dot` as latest event against each actors increments and decrements. This is so a field removal can reset the counter value. However, we don't store a dot per increment (that would be crazy inefficient). Counters work will in this scenario

```
A increments counter at field F by 10
B merges A
A removes field F
B increments counter at field F by 5
A and B merge
```

Counter is at 5 (A's dot for the increment is dropped)

However there is an anomaly

```
A increments counter at field F by 10
B merges A
A increments counter by 5
B removes field F
A and B merge
```

The counter is at 15.

Now, technically, A's first increment _should_ be dropped (should it??) and only the second stand, but that does not happen, as we don't keep a dot per increment. This, too, can be spun in the filesystem sense. If you updated a file and concurrently removed it, you wouldn't expect only the diff to survive, but the whole file.

Personally I'm happy enough with the semantic, to enable reset-remove on counters requires a dot per increment (a counter as set of increments) and that is not worth the overhead.

Happy to rebase once the full round of reviewing is done.

OOOOOOOH, And I removed `add` from the Map API. Problem?
