### PR TITLE
Make map/set interoperable with previous versions 

### DIFF
--- a/src/riak_dt.erl
+++ b/src/riak_dt.erl
@@ -58,6 +58,8 @@
 -callback stats(crdt()) -> [{atom(), number()}].
 -callback stat(atom(), crdt()) -> number() | undefined.
 
+-callback to_version(pos_integer(), crdt()) -> crdt().
+
 -ifdef(EQC).
 % Extra callbacks for any crdt_statem_eqc tests
 

--- a/src/riak_dt_disable_flag.erl
+++ b/src/riak_dt_disable_flag.erl
@@ -32,6 +32,7 @@
 -export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1, stats/1, stat/2]).
 -export([update/4, parent_clock/2]).
 -export([to_binary/2]).
+-export([to_version/2]).
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -export([gen_op/0, init_state/0, update_expected/3, eqc_state_value/1]).
@@ -104,6 +105,11 @@ stats(_) -> [].
 
 -spec stat(atom(), disable_flag()) -> number() | undefined.
 stat(_, _) -> undefined.
+
+-spec to_version(pos_integer(), disable_flag()) -> disable_flag().
+to_version(_Version, Flag) ->
+    Flag.
+
 
 %% priv
 flag_and(on, on) ->

--- a/src/riak_dt_emcntr.erl
+++ b/src/riak_dt_emcntr.erl
@@ -51,6 +51,7 @@
 -export([to_binary/2]).
 -export([stats/1, stat/2]).
 -export([parent_clock/2, update/4]).
+-export([to_version/2]).
 
 %% EQC API
 -ifdef(EQC).
@@ -247,6 +248,9 @@ from_binary(<<?TAG:8/integer, Vers:8/integer, _Bin/binary>>) ->
 from_binary(_Bin) ->
     ?INVALID_BINARY.
 
+-spec to_version(pos_integer(), emcntr()) -> emcntr().
+to_version(_Version, Cntr) ->
+    Cntr.
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_enable_flag.erl
+++ b/src/riak_dt_enable_flag.erl
@@ -32,6 +32,7 @@
 -export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1, stats/1, stat/2]).
 -export([update/4, parent_clock/2]).
 -export([to_binary/2]).
+-export([to_version/2]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -104,6 +105,10 @@ stats(_) -> [].
 -spec stat(atom(), enable_flag()) -> number() | undefined.
 stat(_, _) ->
     undefined.
+
+-spec to_version(pos_integer(), enable_flag()) -> enable_flag().
+to_version(_Version, Flag) ->
+    Flag.
 
 %% priv
 flag_or(on, _) ->

--- a/src/riak_dt_gcounter.erl
+++ b/src/riak_dt_gcounter.erl
@@ -39,6 +39,7 @@
 -export([new/0, new/2, value/1, value/2, update/3, merge/2, equal/2, to_binary/1, from_binary/1, stats/1, stat/2]).
 -export([update/4, parent_clock/2]).
 -export([to_binary/2]).
+-export([to_version/2]).
 
 %% EQC API
 -ifdef(EQC).
@@ -148,6 +149,10 @@ from_binary(<<?TAG:8/integer, Vers:8/integer, _EntriesBin/binary>>) ->
     ?UNSUPPORTED_VERSION(Vers);
 from_binary(_B) ->
     ?INVALID_BINARY.
+
+-spec to_version(pos_integer(), gcounter()) -> gcounter().
+to_version(_Version, C) ->
+    C.
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_gset.erl
+++ b/src/riak_dt_gset.erl
@@ -37,6 +37,7 @@
          to_binary/1, from_binary/1, value/2, stats/1, stat/2]).
 -export([update/4, parent_clock/2]).
 -export([to_binary/2]).
+-export([to_version/2]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -137,6 +138,9 @@ stat(max_element_size, GSet) ->
       end, 0, GSet);
 stat(_, _) -> undefined.
 
+-spec to_version(pos_integer(), gset()) -> gset().
+to_version(_Version, Set) ->
+    Set.
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_lwwreg.erl
+++ b/src/riak_dt_lwwreg.erl
@@ -35,6 +35,7 @@
          equal/2, to_binary/1, from_binary/1, stats/1, stat/2]).
 -export([parent_clock/2, update/4]).
 -export([to_binary/2]).
+-export([to_version/2]).
 
 %% EQC API
 -ifdef(EQC).
@@ -154,6 +155,10 @@ from_binary(<<?TAG:8/integer, Vers:8/integer, _Bin/binary>>) ->
     ?UNSUPPORTED_VERSION(Vers);
 from_binary(_B) ->
     ?INVALID_BINARY.
+
+-spec to_version(pos_integer(), lwwreg()) -> lwwreg().
+to_version(_Version, LWW) ->
+    LWW.
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_map.erl
+++ b/src/riak_dt_map.erl
@@ -538,7 +538,7 @@ filter_dots(Dots, CRDTs, Clock) ->
 %% @private prior versions of the Map stored dots in an
 %% orddict. Orddicts are also lists, fetch the dots, and if they are
 %% from an old version "upgrade" to dict.
--spec fetch_dots(field_name(), entries()) -> field_value().
+-spec fetch_dots(entries(), field_name()) -> any(). %% why dialyzer? Why?
 fetch_dots(Dict, Field) ->
     case ?DICT:fetch(Field, Dict) of
         {Dots, TS} when is_list(Dots) ->

--- a/src/riak_dt_od_flag.erl
+++ b/src/riak_dt_od_flag.erl
@@ -31,6 +31,7 @@
 -export([to_binary/2]).
 -export([precondition_context/1]).
 -export([parent_clock/2]).
+-export([to_version/2]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -200,6 +201,10 @@ to_binary(Vers, _F) ->
 -spec precondition_context(od_flag()) -> riak_dt:context().
 precondition_context({Clock, _Flag, _Deferred}) ->
     Clock.
+
+-spec to_version(pos_integer(), od_flag()) -> od_flag().
+to_version(_Version, Flag) ->
+    Flag.
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_dt_oe_flag.erl
+++ b/src/riak_dt_oe_flag.erl
@@ -28,6 +28,7 @@
 -export([new/0, value/1, value/2, update/3, merge/2, equal/2, from_binary/1, to_binary/1, stats/1, stat/2]).
 -export([update/4, parent_clock/2]).
 -export([to_binary/2]).
+-export([to_version/2]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -141,6 +142,10 @@ stats(OEF) ->
 stat(actor_count, {C, _}) ->
     length(C);
 stat(_, _) -> undefined.
+
+-spec to_version(pos_integer(), oe_flag()) -> oe_flag().
+to_version(_Version, Flag) ->
+    Flag.
 
 
 %% ===================================================================

--- a/src/riak_dt_orset.erl
+++ b/src/riak_dt_orset.erl
@@ -29,6 +29,7 @@
          to_binary/1, from_binary/1, value/2, precondition_context/1, stats/1, stat/2]).
 -export([update/4, parent_clock/2]).
 -export([to_binary/2]).
+-export([to_version/2]).
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
@@ -205,6 +206,11 @@ from_binary(<<?TAG:8/integer, Vers:8/integer, _Bin/binary>>) ->
     ?UNSUPPORTED_VERSION(Vers);
 from_binary(_B) ->
     ?INVALID_BINARY.
+
+-spec to_version(pos_integer(), orset()) -> orset().
+to_version(_Version, Set) ->
+    Set.
+
 
 %% Private
 add_elem(Elem,Token,ORDict) ->

--- a/src/riak_dt_orswot.erl
+++ b/src/riak_dt_orswot.erl
@@ -91,7 +91,10 @@
 
 -export_type([orswot/0, orswot_op/0, binary_orswot/0]).
 
--opaque orswot() :: {riak_dt_vclock:vclock(), entries(), deferred()}.
+-type orswot() :: v1_orswot() | v2_orswot().
+-type v2_orswot() :: {riak_dt_vclock:vclock(), entries(), deferred()}.
+-type v1_orswot() :: {riak_dt_vclock:vclock(), {member(), dots()},
+                      {riak_dt_vclock:vclock(), [member()]}}.
 %% Only removes can be deferred, so a list of members to be removed
 %% per context.
 -type deferred() :: dict(riak_dt_vclock:vclock(), [member()]).

--- a/src/riak_dt_orswot.erl
+++ b/src/riak_dt_orswot.erl
@@ -494,7 +494,7 @@ to_v1({Clock, Entries0, Deferred0}) ->
 -spec from_binary(binary_orswot()) -> {ok, orswot()} | ?UNSUPPORTED_VERSION | ?INVALID_BINARY.
 from_binary(<<?TAG:8/integer, ?V1_VERS:8/integer, B/binary>>) ->
     S = riak_dt:from_binary(B),
-    %% Now upgrdate the structure to dict from orddict
+    %% Now upgrade the structure to dict from orddict
     {ok, to_v2(S)};
 from_binary(<<?TAG:8/integer, ?V2_VERS:8/integer, B/binary>>) ->
     {ok, riak_dt:from_binary(B)};

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -39,6 +39,7 @@
          update/3, merge/2, equal/2, to_binary/1, from_binary/1, stats/1, stat/2]).
 -export([to_binary/2, current_version/1, change_versions/3]).
 -export([parent_clock/2, update/4]).
+-export([to_version/2]).
 
 %% EQC API
 -ifdef(EQC).
@@ -201,6 +202,14 @@ from_binary(<<?TAG:8/integer, Vers:8/integer, _/binary>>) ->
     ?UNSUPPORTED_VERSION(Vers);
 from_binary(_B) ->
     ?INVALID_BINARY.
+
+-spec to_version(pos_integer(), any_pncounter()) -> any_pncounter().
+to_version(_Version, C) ->
+    %% TODO: This module already has a notion of internal format
+    %% versions and they are not in lock-step with the other
+    %% types. However, its versioning is not affected by the map
+    %% format-upgrade bug.
+    C.
 
 -spec current_version(any_pncounter()) -> version().
 current_version(PNCnt) when is_list(PNCnt) ->

--- a/src/riak_dt_pncounter.erl
+++ b/src/riak_dt_pncounter.erl
@@ -204,12 +204,8 @@ from_binary(_B) ->
     ?INVALID_BINARY.
 
 -spec to_version(pos_integer(), any_pncounter()) -> any_pncounter().
-to_version(_Version, C) ->
-    %% TODO: This module already has a notion of internal format
-    %% versions and they are not in lock-step with the other
-    %% types. However, its versioning is not affected by the map
-    %% format-upgrade bug.
-    C.
+to_version(ToVer, C) ->
+    change_versions(current_version(C), ToVer, C).
 
 -spec current_version(any_pncounter()) -> version().
 current_version(PNCnt) when is_list(PNCnt) ->

--- a/test/orswot_eqc.erl
+++ b/test/orswot_eqc.erl
@@ -21,6 +21,7 @@
 
 -module(orswot_eqc).
 
+-ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -469,3 +470,4 @@ model_merge({S1, D1}, {S2, D2}) ->
     S = riak_dt_orset:merge(S1, S2),
     D = riak_dt_orset:merge(D1, D2),
     model_apply_deferred(S, D).
+-endif.


### PR DESCRIPTION
Addresses in part basho/riak#667.

The work from basho/riak_dt#110 was rushed and broken: all orddicts got changed to dicts: even the ones enternal to the map field structure. The to/from_binary calls did not touch or change them, so reading a previous set/map binary into a structure and operating on it was impossible.

Further more, nested sets and maps in maps were not converted by to/from_binary, so again, operating on nested data types was impossible.

I went with the ugly and direct method for adding a function head at all exposed API calls to catch the old orddict structure and transform it to the new dict.

This PR will let you read/work with old sets/maps, it does not address the issue of downgrading from dict style maps/sets to orddict ones.
